### PR TITLE
fix double byte characters broken bug.

### DIFF
--- a/etc/ce-to-ce/1.6.0.0/config.xml.dist
+++ b/etc/ce-to-ce/1.6.0.0/config.xml.dist
@@ -87,10 +87,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.6.0.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.6.1.0/config.xml.dist
+++ b/etc/ce-to-ce/1.6.1.0/config.xml.dist
@@ -87,10 +87,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.6.1.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.6.2.0/config.xml.dist
+++ b/etc/ce-to-ce/1.6.2.0/config.xml.dist
@@ -87,10 +87,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.6.2.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.7.0.0/config.xml.dist
+++ b/etc/ce-to-ce/1.7.0.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.7.0.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.7.0.1/config.xml.dist
+++ b/etc/ce-to-ce/1.7.0.1/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.7.0.1/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.7.0.2/config.xml.dist
+++ b/etc/ce-to-ce/1.7.0.2/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.7.0.2/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.8.0.0/config.xml.dist
+++ b/etc/ce-to-ce/1.8.0.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.8.0.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.8.1.0/config.xml.dist
+++ b/etc/ce-to-ce/1.8.1.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.8.1.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.0.0/config.xml.dist
+++ b/etc/ce-to-ce/1.9.0.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.0.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.0.1/config.xml.dist
+++ b/etc/ce-to-ce/1.9.0.1/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.0.1/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.1.0/config.xml.dist
+++ b/etc/ce-to-ce/1.9.1.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.1.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.1.1/config.xml.dist
+++ b/etc/ce-to-ce/1.9.1.1/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.1.1/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.2.0/config.xml.dist
+++ b/etc/ce-to-ce/1.9.2.0/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.2.0/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.2.1/config.xml.dist
+++ b/etc/ce-to-ce/1.9.2.1/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.2.1/map.xml.dist</map_file>

--- a/etc/ce-to-ce/1.9.2.2/config.xml.dist
+++ b/etc/ce-to-ce/1.9.2.2/config.xml.dist
@@ -92,10 +92,10 @@
         </step>
     </steps>
     <source>
-        <database host="localhost" name="magento1" user="root"/>
+        <database host="localhost" name="magento1" user="root" initStatements="SET NAMES utf8;" />
     </source>
     <destination>
-        <database host="localhost" name="magento2" user="root"/>
+        <database host="localhost" name="magento2" user="root" initStatements="SET NAMES utf8;" />
     </destination>
     <options>
         <map_file>etc/ce-to-ce/1.9.2.2/map.xml.dist</map_file>

--- a/etc/config.xsd
+++ b/etc/config.xsd
@@ -74,6 +74,7 @@
         <xs:attribute name="host" type="xs:string" use="required"/>
         <xs:attribute name="user" type="xs:string" use="required"/>
         <xs:attribute name="password" type="xs:string" use="optional"/>
+        <xs:attribute name="initStatements" type="xs:string" use="required"/>
     </xs:complexType>
 
     <xs:simpleType name="resourceType">

--- a/src/Migration/ResourceModel/Destination.php
+++ b/src/Migration/ResourceModel/Destination.php
@@ -60,6 +60,7 @@ class Destination extends AbstractResource
         $config['password'] = !empty($destination[$destinationType]['password'])
             ? $destination[$destinationType]['password']
             : '';
+        $config['initStatements'] = $destination[$destinationType]['initStatements'];
         return $config;
     }
 

--- a/src/Migration/ResourceModel/Source.php
+++ b/src/Migration/ResourceModel/Source.php
@@ -36,6 +36,7 @@ class Source extends AbstractResource
         $config['password'] = !empty($source[$sourceType]['password'])
             ? $source[$sourceType]['password']
             : '';
+        $config['initStatements'] = $source[$sourceType]['initStatements'];
         return $config;
     }
 


### PR DESCRIPTION
Hi,
I found the reason of double byte characters broken bug.
It's caused by losing mysql connection parameters. By default, PHP's mysql connection uses 'latin1' as its character sets, but Magento uses 'UTF-8'. So double byte characters are always broken without "charset" or "initStatements" option when connecting databases.
