### PR TITLE
Logger define twice in \Migration\Step\ConfigurablePrices\Volume

### DIFF
--- a/src/Migration/Step/ConfigurablePrices/Volume.php
+++ b/src/Migration/Step/ConfigurablePrices/Volume.php
@@ -47,8 +47,7 @@ class Volume extends AbstractVolume
         ResourceModel\Source $source,
         ResourceModel\Destination $destination,
         ProgressBar\LogLevelProcessor $progressBar,
-        Helper $helper,
-        Logger $logger
+        Helper $helper
     ) {
         $this->source = $source;
         $this->destination = $destination;


### PR DESCRIPTION
Logger is define twice in class \Migration\Step\ConfigurablePrices\Volume

Error: 
```
PHP Fatal error:  Redefinition of parameter $logger in /var/www/magento/dev/vendor/magento/data-migration-tool/src/Migration/Step/ConfigurablePrices/Volume.php on line 45
```