### PR TITLE
Add ignore on permission_* tables

### DIFF
--- a/etc/ce-to-ce/1.6.0.0/map.xml.dist
+++ b/etc/ce-to-ce/1.6.0.0/map.xml.dist
@@ -512,6 +512,12 @@
             <ignore>
                 <document>strikeiron_tax_rate</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.6.1.0/map.xml.dist
+++ b/etc/ce-to-ce/1.6.1.0/map.xml.dist
@@ -500,6 +500,12 @@
             <ignore>
                 <document>strikeiron_tax_rate</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.6.2.0/map.xml.dist
+++ b/etc/ce-to-ce/1.6.2.0/map.xml.dist
@@ -500,6 +500,12 @@
             <ignore>
                 <document>strikeiron_tax_rate</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.7.0.0/map.xml.dist
+++ b/etc/ce-to-ce/1.7.0.0/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.7.0.1/map.xml.dist
+++ b/etc/ce-to-ce/1.7.0.1/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.7.0.2/map.xml.dist
+++ b/etc/ce-to-ce/1.7.0.2/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.8.0.0/map.xml.dist
+++ b/etc/ce-to-ce/1.8.0.0/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.8.1.0/map.xml.dist
+++ b/etc/ce-to-ce/1.8.1.0/map.xml.dist
@@ -506,6 +506,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.0.0/map.xml.dist
+++ b/etc/ce-to-ce/1.9.0.0/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.0.1/map.xml.dist
+++ b/etc/ce-to-ce/1.9.0.1/map.xml.dist
@@ -509,6 +509,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.1.0/map.xml.dist
+++ b/etc/ce-to-ce/1.9.1.0/map.xml.dist
@@ -491,6 +491,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.1.1/map.xml.dist
+++ b/etc/ce-to-ce/1.9.1.1/map.xml.dist
@@ -491,6 +491,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.2.0/map.xml.dist
+++ b/etc/ce-to-ce/1.9.2.0/map.xml.dist
@@ -491,6 +491,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/ce-to-ce/1.9.2.1/map.xml.dist
+++ b/etc/ce-to-ce/1.9.2.1/map.xml.dist
@@ -491,6 +491,12 @@
             <ignore>
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
+            <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>


### PR DESCRIPTION
`permission_block` and `permission_variable` can exists on all Magento version (since patch SUPEE-6788)
