### PR TITLE
Don't fail on missing deltalog when source is ignored

### DIFF
--- a/src/Migration/App/Step/AbstractDelta.php
+++ b/src/Migration/App/Step/AbstractDelta.php
@@ -102,14 +102,15 @@ abstract class AbstractDelta implements StageInterface
             if (!$this->source->getDocument($documentName)) {
                 continue;
             }
-            $deltaLogName = $this->source->getDeltaLogName($documentName);
-            if (!isset($sourceDocuments[$deltaLogName])) {
-                throw new \Migration\Exception(sprintf('Deltalog for %s is not installed', $documentName));
-            }
 
             $destinationName = $this->mapReader->getDocumentMap($documentName, MapInterface::TYPE_SOURCE);
             if (!$destinationName) {
                 continue;
+            }
+
+            $deltaLogName = $this->source->getDeltaLogName($documentName);
+            if (!isset($sourceDocuments[$deltaLogName])) {
+                throw new \Migration\Exception(sprintf('Deltalog for %s is not installed', $documentName));
             }
 
             if ($this->source->getRecordsCount($deltaLogName) == 0) {


### PR DESCRIPTION
Currently the delta mode will fail if a table in the `deltalog.xml` file is not present in the source, even if that same table is ignored in the document map. Since the delta won't actually do anything with an ignored table anyway, there's no reason to check for the existence of the source table until we've ruled out the possibility that the table is ignored.