### PR TITLE
Fix type error (php 7.1)

### DIFF
--- a/src/Migration/ResourceModel/AbstractResource.php
+++ b/src/Migration/ResourceModel/AbstractResource.php
@@ -222,7 +222,7 @@ abstract class AbstractResource
      */
     protected function getBytes($memoryLimit)
     {
-        $memoryLimit = trim($memoryLimit);
+        $memoryLimit = (int)trim($memoryLimit);
         $last = strtolower($memoryLimit[strlen($memoryLimit)-1]);
         switch($last) {
             case 'g':


### PR DESCRIPTION
Fix exception: A non well formed numeric value encountered.
trim ouput is string but $memoryLimit should be an int.