### PR TITLE
magento/data-migration-tool#282: Record structure does not match prov…

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -549,7 +549,9 @@ class Data implements StageInterface, RollbackInterface
             ) {
                 continue;
             }
-            if ($attributes[$attributeId]['attribute_code'] == $attributeCode) {
+            if ($attributes[$attributeId]['attribute_code'] == $attributeCode
+            && isset($attributeSetGroups[$record->getValue('attribute_set_id')][$attributeGroupCode])
+            ) {
                 $record->setValue(
                     'attribute_group_id',
                     $attributeSetGroups[$record->getValue('attribute_set_id')][$attributeGroupCode]


### PR DESCRIPTION
Trying to migrate some Eav attribute data and I was getting the exception error. 

[Undefined offset: 9 in vendor/magento/data-migration-tool/src/Migration/Step/Eav/Data.php on line 55  ](https://github.com/magento/data-migration-tool/blob/master/src/Migration/Step/Eav/Data.php#L553)

The issue was rasied for an attribute which does not belong any attribute sets.
So, **I  have added at a condition [at](https://github.com/magento/data-migration-tool/blob/master/src/Migration/Step/Eav/Data.php#L552)** 


`isset($attributeSetGroups[$record->getValue('attribute_set_id')][$attributeGroupCode]) with $attributes[$attributeId]['attribute_code'] == $attributeCode`

```
            if ($attributes[$attributeId]['attribute_code'] == $attributeCode
                && isset($attributeSetGroups[$record->getValue('attribute_set_id')][$attributeGroupCode])
            ) 
```


That  resolve the issue and other attributes was successfully migrated 
