### PR TITLE
Do not override result of integrity checks

### DIFF
--- a/src/Migration/Mode/Data.php
+++ b/src/Migration/Mode/Data.php
@@ -86,10 +86,11 @@ class Data extends AbstractMode implements \Migration\App\Mode\ModeInterface
         foreach ($steps->getSteps() as $stepName => $step) {
             if (!empty($step['integrity'])) {
                 $result = $this->runStage($step['integrity'], $stepName, 'integrity check') && $result;
+                
+                if(!$result) {
+                    throw new Exception('Integrity Check failed');
+                }
             }
-        }
-        if (!$result) {
-            throw new Exception('Integrity Check failed');
         }
     }
 

--- a/src/Migration/Mode/Data.php
+++ b/src/Migration/Mode/Data.php
@@ -82,10 +82,9 @@ class Data extends AbstractMode implements \Migration\App\Mode\ModeInterface
      */
     protected function runIntegrity(StepList $steps)
     {
-        $result = true;
         foreach ($steps->getSteps() as $stepName => $step) {
             if (!empty($step['integrity'])) {
-                $result = $this->runStage($step['integrity'], $stepName, 'integrity check') && $result;
+                $result = $this->runStage($step['integrity'], $stepName, 'integrity check');
                 
                 if (!$result) {
                     throw new Exception('Integrity Check failed');

--- a/src/Migration/Mode/Data.php
+++ b/src/Migration/Mode/Data.php
@@ -87,7 +87,7 @@ class Data extends AbstractMode implements \Migration\App\Mode\ModeInterface
             if (!empty($step['integrity'])) {
                 $result = $this->runStage($step['integrity'], $stepName, 'integrity check') && $result;
                 
-                if(!$result) {
+                if (!$result) {
                     throw new Exception('Integrity Check failed');
                 }
             }


### PR DESCRIPTION
During execution of migration from M1 to M2 (clear magento + few modules) I found that if some integrity check fails in the middle - it continue migration, it should fail it.

I had following result:
```
[2017-06-08 13:18:00][INFO][mode: data][stage: integrity check][step: Data Integrity Step]: started
[2017-06-08 13:18:00][INFO][mode: data][stage: integrity check][step: EAV Step]: started
[2017-06-08 13:18:00][INFO][mode: data][stage: integrity check][step: Customer Attributes Step]: started
[2017-06-08 13:18:00][INFO][mode: data][stage: integrity check][step: Map Step]: started
100% [============================] Remaining Time: 1 sec
[2017-06-08 13:18:50][ERROR]: Destination documents are not mapped: m2_module_table_name
[2017-06-08 13:19:35][INFO][mode: data][stage: integrity check][step: Url Rewrite Step]: started
100% [============================] Remaining Time: 1 sec
...
```