### PR TITLE
Bugfix: url duplicates not resolving if urls in mixed case

### DIFF
--- a/src/Migration/Step/UrlRewrite/Version11410to2000.php
+++ b/src/Migration/Step/UrlRewrite/Version11410to2000.php
@@ -278,7 +278,7 @@ class Version11410to2000 extends DatabaseStage implements StageInterface, Rollba
             && empty($this->duplicateIndex)
         ) {
             foreach ($duplicates as $row) {
-                $this->duplicateIndex[$row['request_path']][] = $row;
+                $this->duplicateIndex[strtolower($row['request_path'])][] = $row;
             }
         }
 
@@ -393,9 +393,11 @@ class Version11410to2000 extends DatabaseStage implements StageInterface, Rollba
                 $destinationRecord->setValue('entity_id', 0);
             }
 
-            if (!empty($this->duplicateIndex[$sourceRecord->getValue('request_path')])) {
+            $normalizedRequestPath = strtolower($sourceRecord->getValue('request_path'));
+            if (!empty($this->duplicateIndex[$normalizedRequestPath])) {
                 $shouldResolve = false;
-                foreach ($this->duplicateIndex[$sourceRecord->getValue('request_path')] as &$duplicate) {
+
+                foreach ($this->duplicateIndex[$normalizedRequestPath] as &$duplicate) {
                     $onStore = $duplicate['store_id'] == $sourceRecord->getValue('store_id');
                     if ($onStore && empty($duplicate['used'])) {
                         $duplicate['used'] = true;


### PR DESCRIPTION
During our import, we found multiple issues where duplicates were found, but not resolved properly due to the _ci nature of the url_rewrite tables. 

To recreate, you can add an entry in the `enterprise_url_rewrite` table to a product's SKU in all lower-case. Then, change the url_key to the sku but in upper case. 

When the url_rewrite_m2<hash> table is created, these are correctly identified as duplicates, but the index of the PHP array doesn't match properly. This fix just changes the index of $duplicateIndex[] to always be lower case, which resolves my issue. 

Happy to provide an M1 database if this would aid debugging
