### PR TITLE
Bugfix: urlRewrite: suffix from core_config_data is not always prefix…

### DIFF
--- a/src/Migration/Step/UrlRewrite/Model/Suffix.php
+++ b/src/Migration/Step/UrlRewrite/Model/Suffix.php
@@ -82,6 +82,7 @@ class Suffix
                 if ($row['store_path'] !== null) {
                     $suffix = $row['store_value'];
                 }
+                $suffix = $this->ensureSuffixBeginsWithDot($suffix);
                 $this->suffixData[$suffixFor][] = [
                     'store_id' => $row['store_id'],
                     'suffix' => $suffix
@@ -96,5 +97,10 @@ class Suffix
         $suffix .= " ELSE '{$suffixDefault}' END";
 
         return $suffix;
+    }
+
+    private function ensureSuffixBeginsWithDot($suffix)
+    {
+        return substr($suffix, 0, 1) === "." ? $suffix : '.' . $suffix;
     }
 }


### PR DESCRIPTION
…ed with .

In our database, the core_config_data table contains product_url_suffix and category_url_suffix as "html", although the migration tool seems to be expecting ".html"

![image](https://user-images.githubusercontent.com/28679828/30876368-49a9c3a8-a2ab-11e7-9aea-cfe349aeddc9.png)

I'm not sure if it's just a bug in the migration tool and the "." is missing or not, but this addition seemed like the least offensive way to fix our issue. After calculating the value of suffix, it just validates it begins with a "." and inserts on if it doesn't. The default_suffix is ".html", so there needs to be a test for that. 

Happy to provide a sample database dump if that would help!
Many thanks