### PR TITLE
Data Migration Tool Release 2.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+2.2.2
+=============
+* Added support for versions:
+
+   * Magento Open Source: 2.2.2
+   * Magento Commerce: 2.2.2
+
+* Fixed bugs:
+
+   * Customer Attribute step did not remember its position
+   * Wrong value for `eav_attribute_group.attribute_group_code` field was set for not product entities
+   * [Issue #355](https://github.com/magento/data-migration-tool/issues/355): Data integrity check errors did not indicate source where it come from
+   * [Issue #378](https://github.com/magento/data-migration-tool/issues/378): Settings step threw an error in case additional fields from extensions in `core_config_data` table
+
 2.2.1
 =============
 * Broken serialized data does not stop migration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,9 @@
 * Fixed bugs:
 
    * Customer Attribute step did not remember its position
-   * Wrong value for `eav_attribute_group.attribute_group_code` field was set for not product entities
-   * [Issue #355](https://github.com/magento/data-migration-tool/issues/355): Data integrity check errors did not indicate source where it come from
-   * [Issue #378](https://github.com/magento/data-migration-tool/issues/378): Settings step threw an error in case additional fields from extensions in `core_config_data` table
+   * Wrong value for `eav_attribute_group.attribute_group_code` field was set for non-product entities
+   * [Issue #355](https://github.com/magento/data-migration-tool/issues/355): Data integrity check errors did not indicate the source of the error
+   * [Issue #378](https://github.com/magento/data-migration-tool/issues/378): Settings step threw an error when additional fields from an extension were added to the `core_config_data` database table
 
 2.2.1
 =============

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/data-migration-tool",
     "description": "Migration Tool",
-    "version": "2.2.1",
+    "version": "2.2.2",
     "require": {
         "symfony/console": "~2.3, !=2.7.0",
         "magento/framework": "~101.0.0",

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2419,6 +2419,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2419,6 +2419,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2404,6 +2404,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2314,6 +2314,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2314,6 +2314,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2314,6 +2314,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2301,6 +2301,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2301,6 +2301,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2301,6 +2301,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2307,6 +2307,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2307,6 +2307,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2307,6 +2307,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2309,6 +2309,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2346,6 +2346,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2346,6 +2346,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2352,6 +2352,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2352,6 +2352,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2352,6 +2352,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2364,6 +2364,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2313,6 +2313,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2313,6 +2313,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2313,6 +2313,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -474,6 +474,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>find_feed_import_codes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2052,6 +2052,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2061,6 +2061,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -474,6 +474,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2061,6 +2061,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -474,6 +474,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -462,6 +462,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -1967,6 +1967,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -1970,6 +1970,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -1990,6 +1990,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -1990,6 +1990,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -1990,6 +1990,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -1990,6 +1990,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -1990,6 +1990,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2002,6 +2002,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2002,6 +2002,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2002,6 +2002,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -1960,6 +1960,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -1960,6 +1960,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -1960,6 +1960,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -1960,6 +1960,9 @@
                 <document>design_config_grid_flat</document>
             </ignore>
             <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
+            <ignore>
                 <document>admin_user_session</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1630,6 +1630,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -468,6 +468,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>paybox_question_number</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1313,6 +1313,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1325,6 +1325,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1630,6 +1630,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -456,6 +456,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>paybox_question_number</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1325,6 +1325,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1630,6 +1630,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -456,6 +456,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>paybox_question_number</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1551,6 +1551,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1551,6 +1551,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1551,6 +1551,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1551,6 +1551,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -462,6 +462,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1548,6 +1548,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1288,6 +1288,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1557,6 +1557,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1557,6 +1557,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1557,6 +1557,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1557,6 +1557,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1291,6 +1291,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1571,6 +1571,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1305,6 +1305,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1571,6 +1571,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -465,6 +465,12 @@
                 <document>catalog_product_entity_tier_price</document>
             </ignore>
             <ignore>
+                <document>permission_block</document>
+            </ignore>
+            <ignore>
+                <document>permission_variable</document>
+            </ignore>
+            <ignore>
                 <document>googlebase_attributes</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1305,6 +1305,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1311,6 +1311,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1571,6 +1571,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1311,6 +1311,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1571,6 +1571,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1311,6 +1311,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1571,6 +1571,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1323,6 +1323,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1583,6 +1583,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1323,6 +1323,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1903,30 +1903,6 @@
             <ignore>
                 <datatype>paypal_settlement_report.report_date</datatype>
             </ignore>
-            <ignore>
-                <datatype>magestore_bannerslider_slider.show_title</datatype>
-            </ignore>
-            <ignore>
-                <datatype>magestore_bannerslider_slider.position_note</datatype>
-            </ignore>
-            <ignore>
-                <datatype>magestore_bannerslider_slider.min_item</datatype>
-            </ignore>
-            <ignore>
-                <datatype>magestore_bannerslider_slider.max_item</datatype>
-            </ignore>
-            <ignore>
-                <field>magestore_bannerslider_banner.style_slide</field>
-            </ignore>
-            <ignore>
-                <field>magestore_bannerslider_banner.caption</field>
-            </ignore>
-            <ignore>
-                <field>magestore_bannerslider_banner.slider_id</field>
-            </ignore>
-            <ignore>
-                <field>magestore_bannerslider_banner.target</field>
-            </ignore>
         </field_rules>
     </destination>
 </map>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1583,6 +1583,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>
@@ -1899,6 +1902,30 @@
             </ignore>
             <ignore>
                 <datatype>paypal_settlement_report.report_date</datatype>
+            </ignore>
+            <ignore>
+                <datatype>magestore_bannerslider_slider.show_title</datatype>
+            </ignore>
+            <ignore>
+                <datatype>magestore_bannerslider_slider.position_note</datatype>
+            </ignore>
+            <ignore>
+                <datatype>magestore_bannerslider_slider.min_item</datatype>
+            </ignore>
+            <ignore>
+                <datatype>magestore_bannerslider_slider.max_item</datatype>
+            </ignore>
+            <ignore>
+                <field>magestore_bannerslider_banner.style_slide</field>
+            </ignore>
+            <ignore>
+                <field>magestore_bannerslider_banner.caption</field>
+            </ignore>
+            <ignore>
+                <field>magestore_bannerslider_banner.slider_id</field>
+            </ignore>
+            <ignore>
+                <field>magestore_bannerslider_banner.target</field>
             </ignore>
         </field_rules>
     </destination>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1610,6 +1610,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1350,6 +1350,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1610,6 +1610,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1350,6 +1350,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1610,6 +1610,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1350,6 +1350,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1610,6 +1610,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1350,6 +1350,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1610,6 +1610,9 @@
             <ignore>
                 <document>design_config_grid_flat</document>
             </ignore>
+            <ignore>
+                <document>release_notification_viewer_log</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1350,6 +1350,9 @@
                 <document>ui_bookmark</document>
             </ignore>
             <ignore>
+                <document>signifyd_case</document>
+            </ignore>
+            <ignore>
                 <document>migration_backup_*</document>
             </ignore>
             <ignore>

--- a/src/Migration/Handler/EavAttributeGroup/SetGroupCode.php
+++ b/src/Migration/Handler/EavAttributeGroup/SetGroupCode.php
@@ -35,7 +35,6 @@ class SetGroupCode extends \Migration\Handler\AbstractHandler implements \Migrat
      */
     private $source;
 
-
     /**
      * @param Config $config
      * @param AttributeGroupNameToCodeMap $groupNameToCodeMap

--- a/src/Migration/Handler/EavAttributeGroup/SetGroupCode.php
+++ b/src/Migration/Handler/EavAttributeGroup/SetGroupCode.php
@@ -23,7 +23,7 @@ class SetGroupCode extends \Migration\Handler\AbstractHandler implements \Migrat
      *
      * @var bool
      */
-    protected $canStart;
+    private $canStart;
 
     /**
      * @var AttributeGroupNameToCodeMap
@@ -31,14 +31,22 @@ class SetGroupCode extends \Migration\Handler\AbstractHandler implements \Migrat
     private $groupNameToCodeMap;
 
     /**
+     * @var Source
+     */
+    private $source;
+
+
+    /**
      * @param Config $config
      * @param AttributeGroupNameToCodeMap $groupNameToCodeMap
+     * @param Source $source
      * @throws Exception
      */
-    public function __construct(Config $config, AttributeGroupNameToCodeMap $groupNameToCodeMap)
+    public function __construct(Config $config, AttributeGroupNameToCodeMap $groupNameToCodeMap, Source $source)
     {
         $this->groupNameToCodeMap = $groupNameToCodeMap;
         $this->canStart = $config->getSource()['type'] == DatabaseStage::SOURCE_TYPE;
+        $this->source = $source;
     }
 
     /**
@@ -50,7 +58,32 @@ class SetGroupCode extends \Migration\Handler\AbstractHandler implements \Migrat
             return;
         }
         $this->validate($recordToHandle);
-        $groupCode = $this->groupNameToCodeMap->getGroupCodeMap($recordToHandle->getValue('attribute_group_name'));
+        $entityType = $this->determineEntityType($recordToHandle->getValue('attribute_set_id'));
+        $groupCode = $this->groupNameToCodeMap->getGroupCodeMap(
+            $recordToHandle->getValue('attribute_group_name'),
+            $entityType
+        );
         $recordToHandle->setValue($this->field, $groupCode);
+    }
+
+    /**
+     * Find entity type by attribute set ID
+     *
+     * @param string $attributeSetId
+     * @return string
+     */
+    private function determineEntityType($attributeSetId)
+    {
+        /** @var Mysql $adapter */
+        $adapter = $this->source->getAdapter();
+        $select = $adapter->getSelect()->from(
+            ['eas' => $this->source->addDocumentPrefix('eav_attribute_set')],
+            []
+        )->join(
+            ['eet' => $this->source->addDocumentPrefix('eav_entity_type')],
+            'eas.entity_type_id = eet.entity_type_id',
+            ['entity_type_code']
+        )->where('eas.attribute_set_id = ?', $attributeSetId);
+        return $select->getAdapter()->fetchOne($select);
     }
 }

--- a/src/Migration/Model/Eav/AttributeGroupNameToCodeMap.php
+++ b/src/Migration/Model/Eav/AttributeGroupNameToCodeMap.php
@@ -13,11 +13,13 @@ class AttributeGroupNameToCodeMap
     /**
      * @var array
      */
-    protected $map = [
-        'General' => 'product-details',
-        'Prices' => 'advanced-pricing',
-        'Design' => 'design',
-        'Images' => 'image-management'
+    private $map = [
+        'catalog_product' => [
+            'General' => 'product-details',
+            'Prices' => 'advanced-pricing',
+            'Design' => 'design',
+            'Images' => 'image-management'
+        ]
     ];
 
     /**
@@ -27,22 +29,26 @@ class AttributeGroupNameToCodeMap
 
     /**
      * @param string $groupName
+     * @param string $entityType
      * @return array
      */
-    public function getGroupCodeMap($groupName)
+    public function getGroupCodeMap($groupName, $entityType)
     {
         $groupNameOriginal = preg_replace('/^' . $this->attributeGroupNamePrefix . '/', '', $groupName);
-        $groupCodeMap = isset($this->map[$groupNameOriginal]) ? $this->map[$groupNameOriginal] : null;
+        $groupCodeMap = isset($this->map[$entityType][$groupNameOriginal])
+            ? $this->map[$entityType][$groupNameOriginal]
+            : null;
         $groupCodeTransformed = preg_replace('/[^a-z0-9]+/', '-', strtolower($groupName));
         $groupCode = $groupCodeMap ?: $groupCodeTransformed;
         return $groupCode;
     }
 
     /**
+     * @param string $entityType
      * @return array
      */
-    public function getMap()
+    public function getMap($entityType)
     {
-        return $this->map;
+        return isset($this->map[$entityType]) ? $this->map[$entityType] : [];
     }
 }

--- a/src/Migration/Step/DataIntegrity/Integrity.php
+++ b/src/Migration/Step/DataIntegrity/Integrity.php
@@ -114,8 +114,10 @@ class Integrity extends DatabaseStage implements StageInterface
      */
     private function buildLogMessage(OrphanRecordsChecker $checker)
     {
+        $message = 'Foreign key (%s) constraint fails on source database.'
+            . ' Orphan records id: %s from `%s`.`%s` has no referenced records in `%s`';
         return sprintf(
-            'Foreign key (%s) constraint fails. Orphan records id: %s from `%s`.`%s` has no referenced records in `%s`',
+            $message,
             $checker->getKeyName(),
             implode(',', $checker->getOrphanRecordsIds()),
             $checker->getChildTable(),

--- a/src/Migration/Step/Eav/Integrity/AttributeGroupNames.php
+++ b/src/Migration/Step/Eav/Integrity/AttributeGroupNames.php
@@ -80,7 +80,7 @@ class AttributeGroupNames
     protected function checkForErrors(array $attributeGroupsOfCatalogProduct, array $attributeSetsOfCatalogProduct)
     {
         $incompatibleDocumentFieldsData = [];
-        $groupNamesToValidate = array_keys($this->groupNameToCodeMap->getMap());
+        $groupNamesToValidate = array_keys($this->groupNameToCodeMap->getMap('catalog_product'));
         foreach ($attributeGroupsOfCatalogProduct as $attributeSetId => $groupNames) {
             if (!empty(array_diff($groupNamesToValidate, $groupNames))) {
                 $error = 'The product attribute set "%s" does not contain all required attribute group names "%s"';

--- a/src/Migration/Step/Settings/Data.php
+++ b/src/Migration/Step/Settings/Data.php
@@ -31,6 +31,17 @@ class Data implements StageInterface
     const CONFIG_FIELD_VALUE = 'value';
 
     /**
+     * @var array
+     */
+    protected $configTableSchema = [
+        self::CONFIG_FIELD_CONFIG_ID,
+        self::CONFIG_FIELD_SCOPE,
+        self::CONFIG_FIELD_SCOPE_ID,
+        self::CONFIG_FIELD_PATH,
+        self::CONFIG_FIELD_VALUE
+    ];
+
+    /**
      * @var Destination
      */
     protected $destination;
@@ -113,6 +124,7 @@ class Data implements StageInterface
         );
         foreach ($sourceRecords as $sourceRecord) {
             $this->progress->advance();
+            $sourceRecord = array_intersect_key($sourceRecord, array_flip($this->configTableSchema));
             if (!$this->readerSettings->isNodeIgnored($sourceRecord[self::CONFIG_FIELD_PATH])) {
                 $sourceRecordPathMapped = $this->readerSettings->getNodeMap($sourceRecord[self::CONFIG_FIELD_PATH]);
                 foreach ($destinationRecords as &$destinationRecord) {

--- a/src/Migration/Step/UrlRewrite/Version11410to2000.php
+++ b/src/Migration/Step/UrlRewrite/Version11410to2000.php
@@ -278,7 +278,7 @@ class Version11410to2000 extends DatabaseStage implements StageInterface, Rollba
             && empty($this->duplicateIndex)
         ) {
             foreach ($duplicates as $row) {
-                $this->duplicateIndex[$row['request_path']][] = $row;
+                $this->duplicateIndex[strtolower($row['request_path'])][] = $row;
             }
         }
 
@@ -391,9 +391,11 @@ class Version11410to2000 extends DatabaseStage implements StageInterface, Rollba
                 $destinationRecord->setValue('entity_id', 0);
             }
 
-            if (!empty($this->duplicateIndex[$sourceRecord->getValue('request_path')])) {
+            $normalizedRequestPath = strtolower($sourceRecord->getValue('request_path'));
+            if (!empty($this->duplicateIndex[$normalizedRequestPath])) {
                 $shouldResolve = false;
-                foreach ($this->duplicateIndex[$sourceRecord->getValue('request_path')] as &$duplicate) {
+
+                foreach ($this->duplicateIndex[$normalizedRequestPath] as &$duplicate) {
                     $onStore = $duplicate['store_id'] == $sourceRecord->getValue('store_id');
                     if ($onStore && empty($duplicate['used'])) {
                         $duplicate['used'] = true;

--- a/tests/integration/testsuite/Migration/Step/DataIntegrity/IntegrityTest.php
+++ b/tests/integration/testsuite/Migration/Step/DataIntegrity/IntegrityTest.php
@@ -106,9 +106,9 @@ class IntegrityTest extends \PHPUnit\Framework\TestCase
                 'result' => false,
                 'messages' => [
                     \Monolog\Logger::ERROR => [
-                        'Foreign key (FK_EAV_ATTR_SET_ENTT_TYPE_ID_EAV_ENTT_TYPE_ENTT_TYPE_ID) constraint fails. ' .
-                        'Orphan records id: 2,3 from `eav_attribute_set`.`entity_type_id` has no referenced records ' .
-                        'in `eav_entity_type`'
+                        'Foreign key (FK_EAV_ATTR_SET_ENTT_TYPE_ID_EAV_ENTT_TYPE_ENTT_TYPE_ID) constraint fails ' .
+                        'on source database. Orphan records id: 2,3 from `eav_attribute_set`.`entity_type_id` '.
+                        'has no referenced records in `eav_entity_type`'
                     ]
                 ]
             ]

--- a/tests/unit/testsuite/Migration/Model/Eav/AttributeGroupNameToCodeMapTest.php
+++ b/tests/unit/testsuite/Migration/Model/Eav/AttributeGroupNameToCodeMapTest.php
@@ -29,12 +29,13 @@ class AttributeGroupNameToCodeMapTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getGroupsData()
      * @param string $groupName
+     * @param string $entityType
      * @param string $groupCode
      * @return void
      */
-    public function testGetGroupCodeMap($groupName, $groupCode)
+    public function testGetGroupCodeMap($groupName, $entityType, $groupCode)
     {
-        $result = $this->model->getGroupCodeMap($groupName);
+        $result = $this->model->getGroupCodeMap($groupName, $entityType);
         $this->assertEquals($result, $groupCode);
     }
 
@@ -44,10 +45,11 @@ class AttributeGroupNameToCodeMapTest extends \PHPUnit\Framework\TestCase
     public function getGroupsData()
     {
         return [
-            ['Migration_General', 'product-details'],
-            ['Migration_Prices', 'advanced-pricing'],
-            ['Migration_Design', 'design'],
-            ['Migration_Something', 'migration-something'],
+            ['Migration_General', 'catalog_product', 'product-details'],
+            ['Migration_Prices', 'catalog_product', 'advanced-pricing'],
+            ['Migration_Design', 'catalog_product', 'design'],
+            ['Migration_Something', 'catalog_product', 'migration-something'],
+            ['Migration_General', 'catalog_category', 'migration-general'],
         ];
     }
 }


### PR DESCRIPTION
## Scope
### Tasks
- [MAGETWO-85265](https://jira.corp.magento.com/browse/MAGETWO-85265) Add a new table release_notification_viewer_log into ignore tag in all map files
- [MAGETWO-85221](https://jira.corp.magento.com/browse/MAGETWO-82764) Data Migration Tool Release 2.2.2


### Bugs
- [MAGETWO-82347](https://jira.corp.magento.com/browse/MAGETWO-82347) Customer Attribute step does not remember its position
- [MAGETWO-81066](https://jira.corp.magento.com/browse/MAGETWO-81066) After migration eav_attribute_group.attribute_group_code setup product-details for not product entity type entities
- [MAGETWO-72093](https://jira.corp.magento.com/browse/MAGETWO-72093) [GitHub] Integrity check error clarification #355
- [MAGETWO-80933](https://jira.corp.magento.com/browse/MAGETWO-80933) [GitHub] Settings step migrates all values of core_config_data table even created by extension #378
- [MAGETWO-81075](https://jira.corp.magento.com/browse/MAGETWO-81075) permission_block and permission_variable can exists on all Magento version (since patch SUPEE-6788)

### Bamboo CI builds
- [ ] [Migration Tool](https://bamboo.corp.magento.com/browse/M2-MT2-79)
