### PR TITLE
Duplicate ignore node found on migration mapping file

### DIFF
--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>


### PR DESCRIPTION
Found two duplicate nodes to ignore `admin_role` and `admin_rule` tables in the `source` node in the `map.xml`.
I found this issue in all `commerce-to-commerce`, `opensource-to-commerce`, and `opensource-to-opensource` platforms mapping files(`map.xml`).
```
<source>
        <document_rules>
            <ignore>
                <document>admin_user</document>
            </ignore>
            <ignore>
                <document>admin_role</document>
            </ignore>
            <ignore>
                <document>admin_rule</document>
            </ignore>
            <ignore>
                <document>admin_role</document>
            </ignore>
</document_rules>
.
.
.
</source>
```