### PR TITLE
Data Migration Tool Release 2.2.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 
 * Fixed bugs:
 
-   * New table `email_abandoned_cart` caused error during migration
+   * New tables `email_abandoned_cart` and `temando_rma_shipment` caused error during migration
    * [Issue #481](https://github.com/magento/data-migration-tool/issues/481): Url rewrite suffix contained only dot symbol
    * [Issue #487](https://github.com/magento/data-migration-tool/issues/487): Important tables were missing in `deltalog.xml.dist`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+2.2.4
+=============
+* Added support for versions:
+
+   * Magento Open Source: 2.2.4
+   * Magento Commerce: 2.2.4
+
+* Fixed bugs:
+
+   * [Issue #481](https://github.com/magento/data-migration-tool/issues/481): Url rewrite suffix contained only dot symbol
+   * [Issue #487](https://github.com/magento/data-migration-tool/issues/487): Important tables were missing in `deltalog.xml.dist`
+
+
 2.2.3
 =============
 * Added support for versions:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 
 * Fixed bugs:
 
+   * New table `email_abandoned_cart` caused error during migration
    * [Issue #481](https://github.com/magento/data-migration-tool/issues/481): Url rewrite suffix contained only dot symbol
    * [Issue #487](https://github.com/magento/data-migration-tool/issues/487): Important tables were missing in `deltalog.xml.dist`
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/data-migration-tool",
     "description": "Migration Tool",
-    "version": "2.2.3",
+    "version": "2.2.4",
     "require": {
         "symfony/console": "~2.3, !=2.7.0",
         "magento/framework": "~101.0.0",

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2510,6 +2510,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2510,6 +2510,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2498,6 +2498,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2513,6 +2513,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2975,6 +3008,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2510,6 +2510,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2510,6 +2510,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2498,6 +2498,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2513,6 +2513,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2975,6 +3008,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2498,6 +2498,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2960,6 +2993,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2495,6 +2495,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2483,6 +2483,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2495,6 +2495,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2486,6 +2486,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2933,6 +2966,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2483,6 +2483,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2471,6 +2471,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2483,6 +2483,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2486,6 +2486,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2930,6 +2963,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2483,6 +2483,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2471,6 +2471,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2483,6 +2483,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2393,6 +2393,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2405,6 +2405,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2408,6 +2408,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2786,6 +2819,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2405,6 +2405,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2393,6 +2393,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2405,6 +2405,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2408,6 +2408,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2786,6 +2819,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2405,6 +2405,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2393,6 +2393,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2405,6 +2405,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2408,6 +2408,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2786,6 +2819,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2405,6 +2405,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2392,6 +2392,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2380,6 +2380,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2395,6 +2395,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2712,6 +2745,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2392,6 +2392,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2380,6 +2380,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2395,6 +2395,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2712,6 +2745,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2392,6 +2392,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2380,6 +2380,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2395,6 +2395,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2712,6 +2745,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2398,6 +2398,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2386,6 +2386,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2401,6 +2401,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2724,6 +2757,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2398,6 +2398,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2401,6 +2401,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2715,6 +2748,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2398,6 +2398,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2386,6 +2386,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2398,6 +2398,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2401,6 +2401,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2715,6 +2748,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2398,6 +2398,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2386,6 +2386,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2398,6 +2398,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2400,6 +2400,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2388,6 +2388,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2400,6 +2400,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2403,6 +2403,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2717,6 +2750,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2440,6 +2440,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2754,6 +2787,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2425,6 +2425,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2437,6 +2437,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2440,6 +2440,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2754,6 +2787,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2425,6 +2425,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2437,6 +2437,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2443,6 +2443,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2443,6 +2443,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2446,6 +2446,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2760,6 +2793,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2431,6 +2431,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2443,6 +2443,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2443,6 +2443,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2446,6 +2446,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2760,6 +2793,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2431,6 +2431,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2443,6 +2443,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2443,6 +2443,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2446,6 +2446,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2760,6 +2793,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2431,6 +2431,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2455,6 +2455,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2458,6 +2458,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2772,6 +2805,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2455,6 +2455,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2443,6 +2443,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2404,6 +2404,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2407,6 +2407,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2721,6 +2754,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2404,6 +2404,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2404,6 +2404,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2407,6 +2407,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2721,6 +2754,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2404,6 +2404,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2404,6 +2404,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2392,6 +2392,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2407,6 +2407,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2721,6 +2754,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2404,6 +2404,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2569,6 +2569,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2569,6 +2569,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2572,6 +2572,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2886,6 +2919,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2557,6 +2557,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2569,6 +2569,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2569,6 +2569,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2572,6 +2572,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2886,6 +2919,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2557,6 +2557,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2569,6 +2569,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2569,6 +2569,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2572,6 +2572,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2886,6 +2919,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2557,6 +2557,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2569,6 +2569,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2569,6 +2569,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2572,6 +2572,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2886,6 +2919,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>catalog_category_entity.created_in</field>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2557,6 +2557,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/deltalog.xml.dist
+++ b/etc/commerce-to-commerce/deltalog.xml.dist
@@ -37,6 +37,7 @@
         <document key="entity_id">sales_flat_shipment_item</document>
         <document key="entity_id">sales_flat_shipment_track</document>
         <document key="entity_id">sales_flat_shipment_grid</document>
+        <document key="entity_id">sales_flat_shipment_comment</document>
         <document key="entity_id">sales_flat_creditmemo</document>
         <document key="entity_id">sales_flat_creditmemo_item</document>
         <document key="entity_id">sales_flat_creditmemo_grid</document>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2133,6 +2133,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2148,6 +2148,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -3148,6 +3181,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2145,6 +2145,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2145,6 +2145,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2154,6 +2154,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2142,6 +2142,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2157,6 +2157,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -3178,6 +3211,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2154,6 +2154,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2157,6 +2157,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -3175,6 +3208,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2154,6 +2154,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2142,6 +2142,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2154,6 +2154,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2976,6 +3009,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2976,6 +3009,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2976,6 +3009,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2954,6 +2987,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2060,6 +2060,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2063,6 +2063,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2951,6 +2984,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2048,6 +2048,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2954,6 +2987,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2954,6 +2987,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2954,6 +2987,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2051,6 +2051,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2063,6 +2063,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2066,6 +2066,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2954,6 +2987,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2063,6 +2063,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2086,6 +2086,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2974,6 +3007,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2071,6 +2071,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2083,6 +2083,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2086,6 +2086,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2974,6 +3007,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2071,6 +2071,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2083,6 +2083,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2086,6 +2086,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2974,6 +3007,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2071,6 +2071,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2083,6 +2083,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2086,6 +2086,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2974,6 +3007,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2071,6 +2071,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2083,6 +2083,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2086,6 +2086,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2974,6 +3007,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2071,6 +2071,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2083,6 +2083,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2098,6 +2098,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2986,6 +3019,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2095,6 +2095,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2095,6 +2095,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2098,6 +2098,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2986,6 +3019,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2095,6 +2095,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2095,6 +2095,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2098,6 +2098,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2986,6 +3019,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2095,6 +2095,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2095,6 +2095,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2083,6 +2083,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2053,6 +2053,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2041,6 +2041,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2056,6 +2056,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2944,6 +2977,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2053,6 +2053,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2053,6 +2053,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2041,6 +2041,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2056,6 +2056,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2944,6 +2977,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2053,6 +2053,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2053,6 +2053,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2041,6 +2041,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2056,6 +2056,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2944,6 +2977,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2053,6 +2053,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2053,6 +2053,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2041,6 +2041,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2056,6 +2056,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2944,6 +2977,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2053,6 +2053,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2053,6 +2053,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2041,6 +2041,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2056,6 +2056,39 @@
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>
@@ -2944,6 +2977,9 @@
             </ignore>
             <ignore>
                 <field>quote_address.gw_card_price_incl_tax</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>sales_order.gw_base_price_incl_tax</field>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2053,6 +2053,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>temando_rma_shipment</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/deltalog.xml.dist
+++ b/etc/opensource-to-commerce/deltalog.xml.dist
@@ -37,6 +37,7 @@
         <document key="entity_id">sales_flat_shipment_item</document>
         <document key="entity_id">sales_flat_shipment_track</document>
         <document key="entity_id">sales_flat_shipment_grid</document>
+        <document key="entity_id">sales_flat_shipment_comment</document>
         <document key="entity_id">sales_flat_creditmemo</document>
         <document key="entity_id">sales_flat_creditmemo_item</document>
         <document key="entity_id">sales_flat_creditmemo_grid</document>
@@ -50,6 +51,7 @@
         <document key="tax_id">sales_order_tax</document>
         <document key="tax_item_id">sales_order_tax_item</document>
         <document key="entity_id">sales_flat_order</document>
+        <document key="transaction_id">sales_payment_transaction</document>
     </group>
     <group name="delta_log">
         <document key="visitor_id">log_visitor</document>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1541,6 +1541,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1541,6 +1541,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1541,6 +1541,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1887,6 +1920,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>cataloginventory_stock_item.is_decimal_divided</field>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1529,6 +1529,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1541,9 +1541,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1553,6 +1553,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1553,6 +1553,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1553,9 +1553,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1541,6 +1541,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1553,6 +1553,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1923,6 +1956,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>cataloginventory_stock_item.is_decimal_divided</field>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1553,6 +1553,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1553,6 +1553,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1553,9 +1553,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1541,6 +1541,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1553,6 +1553,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1923,6 +1956,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>cataloginventory_stock_item.is_decimal_divided</field>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1838,6 +1871,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>paypal_settlement_report_row.store_id</field>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1838,6 +1871,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>paypal_settlement_report_row.store_id</field>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1838,6 +1871,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>paypal_settlement_report_row.store_id</field>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1831,6 +1864,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1516,6 +1516,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1828,6 +1861,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1516,6 +1516,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1516,6 +1516,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1516,9 +1516,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1504,6 +1504,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1837,6 +1870,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1837,6 +1870,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1837,6 +1870,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1519,6 +1519,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1837,6 +1870,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1507,6 +1507,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1519,6 +1519,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1519,6 +1519,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1519,9 +1519,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1533,9 +1533,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1533,6 +1533,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1533,6 +1533,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1851,6 +1884,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1521,6 +1521,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1533,9 +1533,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1533,6 +1533,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1533,6 +1533,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1851,6 +1884,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1521,6 +1521,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1533,9 +1533,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1533,6 +1533,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1533,6 +1533,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1851,6 +1884,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1521,6 +1521,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1533,9 +1533,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1533,6 +1533,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1533,6 +1533,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1851,6 +1884,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1521,6 +1521,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1533,9 +1533,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1533,6 +1533,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1533,6 +1533,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1851,6 +1884,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1521,6 +1521,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1545,9 +1545,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1545,6 +1545,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1863,6 +1896,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1545,6 +1545,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1545,6 +1545,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1533,6 +1533,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1545,9 +1545,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1545,6 +1545,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1863,6 +1896,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1545,6 +1545,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1545,6 +1545,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1572,6 +1572,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1923,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1572,6 +1572,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1923,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1572,6 +1572,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1923,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1572,6 +1572,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1923,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1572,6 +1572,39 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1923,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1572,6 +1572,40 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>amazon_customer</document>
+                <document>amazon_customer</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_authorization</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_capture</document>
+            </ignore>
+            <ignore>
+                <document>amazon_pending_refund</document>
+            </ignore>
+            <ignore>
+                <document>amazon_quote</document>
+            </ignore>
+            <ignore>
+                <document>amazon_sales_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_core_order</document>
+            </ignore>
+            <ignore>
+                <document>klarna_payments_quote</document>
+            </ignore>
+            <ignore>
+                <document>vertex_customer_code</document>
+            </ignore>
+            <ignore>
+                <document>vertex_invoice_sent</document>
+            </ignore>
+            <ignore>
+                <document>vertex_taxrequest</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>
@@ -1890,6 +1924,9 @@
             </ignore>
             <ignore>
                 <field>sales_order.send_email</field>
+            </ignore>
+            <ignore>
+                <field>quote_item.is_excluded_product</field>
             </ignore>
             <ignore>
                 <field>checkout_agreement.mode</field>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1572,6 +1572,9 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_rma_shipment</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1572,9 +1572,6 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
-                <document>temando_rma_shipment</document>
-            </ignore>
-            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1560,6 +1560,9 @@
                 <document>email_wishlist</document>
             </ignore>
             <ignore>
+                <document>email_abandoned_cart</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1572,6 +1572,15 @@
                 <document>temando_shipment</document>
             </ignore>
             <ignore>
+                <document>temando_collection_point_search</document>
+            </ignore>
+            <ignore>
+                <document>temando_order_collection_point</document>
+            </ignore>
+            <ignore>
+                <document>temando_quote_collection_point</document>
+            </ignore>
+            <ignore>
                 <document>amazon_customer</document>
                 <document>amazon_customer</document>
             </ignore>

--- a/etc/opensource-to-opensource/deltalog.xml.dist
+++ b/etc/opensource-to-opensource/deltalog.xml.dist
@@ -37,6 +37,7 @@
         <document key="entity_id">sales_flat_shipment_item</document>
         <document key="entity_id">sales_flat_shipment_track</document>
         <document key="entity_id">sales_flat_shipment_grid</document>
+        <document key="entity_id">sales_flat_shipment_comment</document>
         <document key="entity_id">sales_flat_creditmemo</document>
         <document key="entity_id">sales_flat_creditmemo_item</document>
         <document key="entity_id">sales_flat_creditmemo_grid</document>
@@ -50,6 +51,7 @@
         <document key="tax_id">sales_order_tax</document>
         <document key="tax_item_id">sales_order_tax_item</document>
         <document key="entity_id">sales_flat_order</document>
+        <document key="transaction_id">sales_payment_transaction</document>
     </group>
     <group name="delta_log">
         <document key="visitor_id">log_visitor</document>

--- a/src/Migration/Step/UrlRewrite/Model/Suffix.php
+++ b/src/Migration/Step/UrlRewrite/Model/Suffix.php
@@ -82,7 +82,7 @@ class Suffix
                 if ($row['store_path'] !== null) {
                     $suffix = $row['store_value'];
                 }
-                $suffix = $this->ensureSuffixBeginsWithDot($suffix);
+                $suffix = ($suffix) ? $this->ensureSuffixBeginsWithDot($suffix) : $suffix;
                 $this->suffixData[$suffixFor][] = [
                     'store_id' => $row['store_id'],
                     'suffix' => $suffix


### PR DESCRIPTION
## Scope
### Tasks
- [MAGETWO-90169](https://jira.corp.magento.com/browse/MAGETWO-90169) Adapt Data Migration Tool to the new bundled extensions
- [MAGETWO-89790](https://jira.corp.magento.com/browse/MAGETWO-89790) Data Migration Tool Release 2.2.4

### Bugs
- [MAGETWO-89312](https://jira.corp.magento.com/browse/MAGETWO-89312) [GigHub] Url rewrite suffix contain only dot symbol #481
- [MAGETWO-89898](https://jira.corp.magento.com/browse/MAGETWO-89898) [GigHub] Several important tables are missing in deltalog.xml.dist file #487
- [MAGETWO-90039](https://jira.corp.magento.com/browse/MAGETWO-90039) New table email_abandoned_cart caused error during migration to Magento 2.2.4

### Bamboo CI builds
- [ ] [Migration Tool](https://bamboo.corp.magento.com/browse/M2-MT2-100)
