### PR TITLE
Update Helper.php

### DIFF
--- a/src/Migration/Step/OrderGrids/Helper.php
+++ b/src/Migration/Step/OrderGrids/Helper.php
@@ -171,6 +171,7 @@ class Helper
             'subtotal' => 'sales_order.base_subtotal',
             'shipping_and_handling' => 'sales_order.base_shipping_amount',
             'grand_total' => 'sales_invoice.grand_total',
+            'base_grand_total' => 'sales_invoice.base_grand_total',
             'created_at' => 'sales_invoice.created_at',
             'updated_at' => 'sales_invoice.updated_at'
         ];


### PR DESCRIPTION
I have migrated from mangeto 1.9.0.1 to mangeto 2.2.4. All data including order,invoice,shipments migrated successfully.
Field not migrated from
Table : sales_order_invoice_grid
Field name : base_grand_total is not migrated and it show 'null' in value in invoice grid table.

Though base_grand_total is migrated in invoice entity table. It is only missing from invoice grid table.
I think it is missing from column mapping function in below file.
File : vendor\magento\data-migration-tool\src\Migration\Step\OrderGrids\Helper.php