### PR TITLE
Removed duplicate ignore mapping of 'admin_role' and 'admin_rule' document_rules for 'opensource-to-commerce' platform.

### DIFF
--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -483,12 +483,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -486,12 +486,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -492,12 +492,6 @@
                 <document>sales_flat_order</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>enterprise_url_rewrite</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -456,12 +456,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -456,12 +456,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -456,12 +456,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -444,12 +444,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -447,12 +447,6 @@
                 <document>admin_rule</document>
             </ignore>
             <ignore>
-                <document>admin_role</document>
-            </ignore>
-            <ignore>
-                <document>admin_rule</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_affected_product</document>
             </ignore>
             <ignore>


### PR DESCRIPTION
Related to my previous PR: https://github.com/magento/data-migration-tool/pull/488

Found **two duplicate nodes** to ignore `admin_role ` and `admin_rule ` tables in the source node in the **map.xml**.
I fixed this issue for `opensource-to-commerce` platform mapping files(`map.xml`).

```<source>
        <document_rules>
            <ignore>
                <document>admin_role</document>
            </ignore>
            <ignore>
                <document>admin_rule</document>
            </ignore>
            <ignore>
                <document>admin_role</document>
            </ignore>
            <ignore>
                <document>admin_rule</document>
            </ignore>
</document_rules>
.
.
.
</source>```