### PR TITLE
Incorrect record transformation

### DIFF
--- a/src/Migration/RecordTransformer.php
+++ b/src/Migration/RecordTransformer.php
@@ -127,25 +127,21 @@ class RecordTransformer
     protected function copy(Record $from, Record $to)
     {
         $sourceDocumentName = $this->sourceDocument->getName();
-        $data = $from->getData();
         $sourceFields = $from->getFields();
-        $destinationFields = $to->getFields();
         foreach ($sourceFields as $key => $field) {
             if ($this->mapReader->isFieldIgnored($sourceDocumentName, $field, MapInterface::TYPE_SOURCE)) {
                 unset($sourceFields[$key]);
-                unset($data[$field]);
             }
         }
-        $diff = array_diff($sourceFields, $destinationFields);
-        foreach ($diff as $field) {
+
+        $data = [];
+        foreach ($sourceFields as $field) {
             if (!$this->mapReader->isFieldIgnored($sourceDocumentName, $field, MapInterface::TYPE_SOURCE)) {
                 $fieldMap = $this->mapReader->getFieldMap($sourceDocumentName, $field, MapInterface::TYPE_SOURCE);
-                if ($fieldMap != $field) {
-                    $data[$fieldMap] = $from->getValue($field);
-                }
+                $data[$fieldMap] = $from->getValue($field);
             }
-            unset($data[$field]);
         }
+
         foreach ($data as $key => $value) {
             $to->setValue($key, $value);
         }

--- a/src/Migration/RecordTransformer.php
+++ b/src/Migration/RecordTransformer.php
@@ -134,16 +134,9 @@ class RecordTransformer
             }
         }
 
-        $data = [];
         foreach ($sourceFields as $field) {
-            if (!$this->mapReader->isFieldIgnored($sourceDocumentName, $field, MapInterface::TYPE_SOURCE)) {
-                $fieldMap = $this->mapReader->getFieldMap($sourceDocumentName, $field, MapInterface::TYPE_SOURCE);
-                $data[$fieldMap] = $from->getValue($field);
-            }
-        }
-
-        foreach ($data as $key => $value) {
-            $to->setValue($key, $value);
+            $fieldMap = $this->mapReader->getFieldMap($sourceDocumentName, $field, MapInterface::TYPE_SOURCE);
+            $to->setValue($fieldMap, $from->getValue($field));
         }
     }
 }


### PR DESCRIPTION
When the source and destintaion tables have column with the same name, but the values from the source table must be moved to a different destination column, the data migration tool doesn't work correctly.

**For example:** Magneto 1 contains the `easyslide_slides` table, which contains the following columns: `slide_id`, `image`, `url`, `target`, `target_mode`.
But these columns are mixed up. They contain incorrect data.
When the developer made a version for Magento 2, he decided to put the columns in order. This way, the column names  are preserved, but the data is swapped.

I use `<move>` rules for these fields:
`image` -> `title`
`url` -> `image`
`target` -> `url`
`target_mode` -> `tagret`

But the result data is incorrect. Since the record transformer ignores the eponymous record fields using `array_diff` https://github.com/magento/data-migration-tool/blob/2.2-develop/src/Migration/RecordTransformer.php#L139

Thanks!