### PR TITLE
#608 Change data array into array of entity_ids

### DIFF
--- a/src/Migration/Step/OrderGridsEE/Delta.php
+++ b/src/Migration/Step/OrderGridsEE/Delta.php
@@ -63,14 +63,22 @@ class Delta extends \Migration\Step\OrderGrids\Delta
 
             $destinationDocument = $documentMap[$sourceDocName];
             do {
+                $idArray = array();
+                if (is_array($items[0])) {
+                    foreach ($items as $key => $value) {
+                        $idArray[] = $value[$idKey];
+                    }
+                } else {
+                    $idArray = $items;
+                }
                 $this->destination->deleteRecords(
                     $this->destination->addDocumentPrefix($destinationDocument),
                     $idKey,
-                    $items
+                    $idArray
                 );
                 $documentNameDelta = $this->source->getDeltaLogName($sourceDocName);
                 $documentNameDelta = $this->source->addDocumentPrefix($documentNameDelta);
-                $this->markRecordsProcessed($documentNameDelta, $idKey, $items);
+                $this->markRecordsProcessed($documentNameDelta, $idKey, $idArray);
             } while (!empty($items = $this->source->getChangedRecords($sourceDocName, $idKey, $page++)));
         }
         return true;


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->
This takes the array of items and extracts the entity_ids for use with the `deleteRecords` method

### Fixed Issues (if relevant)
1. magento/data-migration-tool#608: Sales Order Grid - Array to string conversion exception when running Deltas

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Run a full Data migration from Magento 1.14.2.3 to Magento 2.2.6
2. Place orders on Magento 1
3. Run a Delta Data migration

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 