### PR TITLE
solves issue 574

### DIFF
--- a/src/Migration/Handler/EavAttribute/ConvertConfigurableAttribute.php
+++ b/src/Migration/Handler/EavAttribute/ConvertConfigurableAttribute.php
@@ -37,10 +37,27 @@ class ConvertConfigurableAttribute extends AbstractHandler
         $this->validate($recordToHandle);
         $sourceModel = $recordToHandle->getValue($this->field);
         $oppositeRecordValue = $oppositeRecord->getValue($this->field);
-        if (empty($sourceModel) && !empty($oppositeRecordValue)) {
+        if (!empty($sourceModel) && !empty($oppositeRecordValue)) {
+            $recordToHandle->setValue($this->field, $this->merge($sourceModel, $oppositeRecordValue));
+        } elseif (empty($sourceModel) && !empty($oppositeRecordValue)) {
             $recordToHandle->setValue($this->field, $oppositeRecord->getValue($this->field));
         } elseif (empty($sourceModel) || $recordToHandle->getValue('is_configurable')) {
             $recordToHandle->setValue($this->field, null);
         }
+    }
+
+    /**
+     * Merges the apply_to field of recordToHandle and oppositeRecord
+     *
+     * @param string $sourceModel
+     * @param string $oppositeRecordValue
+     * @return string
+     */
+    private function merge($sourceModel, $oppositeRecordValue)
+    {
+        return implode(
+            ',',
+            explode(',', $sourceModel) + explode(',', $oppositeRecordValue)
+        );
     }
 }


### PR DESCRIPTION

### Description
this fix treats the case when an attribute (such as price) already contains an "apply_to" value.
is MAGETWO-94160

### Fixed Issues (if relevant)
1. magento/data-migration-tool# 574: After migration, Grouped products want a price?

### Manual testing scenarios
I used sample data (Magento 1.9.4.0) and migrated it to Magento 2.2.7. The scenario should hold for all versions. 

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 