### PR TITLE
Fix "Url Rewrite Step" data source pagination

### DIFF
--- a/src/Migration/Step/UrlRewrite/Version11300to2000.php
+++ b/src/Migration/Step/UrlRewrite/Version11300to2000.php
@@ -294,6 +294,7 @@ class Version11300to2000 extends DatabaseStage implements StageInterface, Rollba
             $this->migrateRewrites($records, $destinationRecords);
             $this->destination->saveRecords($destinationDocument->getName(), $destinationRecords);
             $this->destination->saveRecords($destProductCategory->getName(), $destProductCategoryRecords);
+            $this->source->setLastLoadedRecord($sourceDocument->getName(), end($data));
         }
         $this->copyEavData('catalog_category_entity_url_key', 'catalog_category_entity_varchar', 'category');
         $this->copyEavData('catalog_product_entity_url_key', 'catalog_product_entity_varchar', 'product');

--- a/src/Migration/Step/UrlRewrite/Version11410to2000.php
+++ b/src/Migration/Step/UrlRewrite/Version11410to2000.php
@@ -299,6 +299,7 @@ class Version11410to2000 extends DatabaseStage implements StageInterface, Rollba
             $this->migrateRewrites($records, $destinationRecords);
             $this->destination->saveRecords($destinationDocument->getName(), $destinationRecords);
             $this->destination->saveRecords($destProductCategory->getName(), $destProductCategoryRecords);
+            $this->source->setLastLoadedRecord($sourceDocument->getName(), end($data));
         }
         $this->copyEavData('catalog_category_entity_url_key', 'catalog_category_entity_varchar', 'category');
         $this->copyEavData('catalog_product_entity_url_key', 'catalog_product_entity_varchar', 'product');

--- a/src/Migration/Step/UrlRewrite/Version191to2000.php
+++ b/src/Migration/Step/UrlRewrite/Version191to2000.php
@@ -220,6 +220,7 @@ class Version191to2000 extends \Migration\Step\DatabaseStage implements Rollback
                 $destinationRecords->addRecord($destRecord);
             }
 
+            $this->source->setLastLoadedRecord(self::SOURCE, end($bulk));
             $this->progress->advance();
             $this->destination->saveRecords(self::DESTINATION, $destinationRecords);
             $this->destination->saveRecords(self::DESTINATION_PRODUCT_CATEGORY, $destProductCategoryRecords);


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/data-migration-tool#682: Incorrect url rewrite record pagination

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Set `bulk_size` property to 10
2. Have at least 30 url rewrites in magento 1
3. Add
```php
if ($documentName === 'core_url_rewrite') {
	var_dump([
		$pageNumber,
		$select->__toString()
	]);
}
```
to [Adapter\Mysql::loadPage](https://github.com/magento/data-migration-tool/blob/2.3-develop/src/Migration/ResourceModel/Adapter/Mysql.php#L109) method before [$result = $this->resourceAdapter->fetchAll($select)](https://github.com/magento/data-migration-tool/blob/2.3-develop/src/Migration/ResourceModel/Adapter/Mysql.php#L120) to see the pagination queries

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 