### PR TITLE
magento/data-migration-tool#: Set "urn:magento:module:Magento_DataMigrationTool" a namespace schema location

### DIFF
--- a/etc/commerce-to-commerce/1.11.0.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.11.0.0/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.11.0.0/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.11.0.1/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.11.0.1/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.11.0.2/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.11.0.2/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.11.1.0/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.11.1.0/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.11.2.0/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.11.2.0/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.12.0.0/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.12.0.1/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.12.0.2/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.0/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.1/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.10/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.10/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.2/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.3/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.4/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.6/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.7/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.8/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.3.9/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.4.0/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.4.1/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/config.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/commerce-to-commerce/1.14.4.2/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/commerce-to-commerce/class-map.xml.dist
+++ b/etc/commerce-to-commerce/class-map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../class-map.xsd">
+<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/class-map.xsd">
     <rename>
         <from>catalogrule/rule_condition_combine</from>
         <to>Magento\CatalogRule\Model\Rule\Condition\Combine</to>

--- a/etc/commerce-to-commerce/customer-attr-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/customer-attr-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">enterprise_customer_sales_flat_order</document>
         <document key="entity_id">enterprise_customer_sales_flat_order_address</document>

--- a/etc/commerce-to-commerce/customer-attr-map.xml.dist
+++ b/etc/commerce-to-commerce/customer-attr-map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/commerce-to-commerce/customer-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/commerce-to-commerce/customer-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/customer-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">customer_entity</document>
         <document key="value_id">customer_entity_datetime</document>

--- a/etc/commerce-to-commerce/deltalog.xml.dist
+++ b/etc/commerce-to-commerce/deltalog.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="delta_map">
         <document key="catalog_compare_item_id">catalog_compare_item</document>
         <document key="item_id">cataloginventory_stock_item</document>

--- a/etc/commerce-to-commerce/eav-attribute-groups.xml.dist
+++ b/etc/commerce-to-commerce/eav-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="ignore">
         <attribute type="catalog_product">msrp_enabled</attribute>
         <attribute type="catalog_product">group_price</attribute>

--- a/etc/commerce-to-commerce/eav-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/eav-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/etc/commerce-to-commerce/log-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/log-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document>log_visitor</document>
     </group>

--- a/etc/commerce-to-commerce/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/map-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/map-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="destination_documents_update_on_duplicate">
         <document key="query_text,store_id">search_query</document>
         <document key="visitor_id,product_id">report_viewed_product_index</document>

--- a/etc/commerce-to-commerce/map-eav.xml.dist
+++ b/etc/commerce-to-commerce/map-eav.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/commerce-to-commerce/map-log.xml.dist
+++ b/etc/commerce-to-commerce/map-log.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/commerce-to-commerce/map-sales.xml.dist
+++ b/etc/commerce-to-commerce/map-sales.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/commerce-to-commerce/map-stores.xml.dist
+++ b/etc/commerce-to-commerce/map-stores.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/commerce-to-commerce/map-tier-price.xml.dist
+++ b/etc/commerce-to-commerce/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/commerce-to-commerce/order-grids-document-groups.xml.dist
+++ b/etc/commerce-to-commerce/order-grids-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">sales_flat_order</document>
         <document key="entity_id">sales_flat_order_address</document>

--- a/etc/commerce-to-commerce/settings.xml.dist
+++ b/etc/commerce-to-commerce/settings.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>advanced/modules_disable_output/*</path>

--- a/etc/commerce-to-commerce/visual_merchandiser_attribute_groups.xml.dist
+++ b/etc/commerce-to-commerce/visual_merchandiser_attribute_groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="catalog_category_entity_varchar">
         <attribute>value_id</attribute>
         <attribute>attribute_id</attribute>

--- a/etc/commerce-to-commerce/visual_merchandiser_document_groups.xml.dist
+++ b/etc/commerce-to-commerce/visual_merchandiser_document_groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document>merchandiser_category_values</document>
     </group>

--- a/etc/commerce-to-commerce/visual_merchandiser_map.xml.dist
+++ b/etc/commerce-to-commerce/visual_merchandiser_map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/opensource-to-commerce/1.6.0.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.6.0.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-commerce/1.6.0.0/deltalog.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/deltalog.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="delta_map">
         <document key="catalog_compare_item_id">catalog_compare_item</document>
         <document key="item_id">cataloginventory_stock_item</document>

--- a/etc/opensource-to-commerce/1.6.0.0/map-customer.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.6.1.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-commerce/1.6.1.0/map-customer.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.6.2.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-commerce/1.6.2.0/map-customer.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/config.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.1/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.10/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.2/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.3/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.4/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.6/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.7/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.8/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.3.9/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.4.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.4.1/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/config.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-commerce/1.9.4.2/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-commerce/class-map.xml.dist
+++ b/etc/opensource-to-commerce/class-map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../class-map.xsd">
+<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/class-map.xsd">
     <rename>
         <from>catalogrule/rule_condition_combine</from>
         <to>Magento\CatalogRule\Model\Rule\Condition\Combine</to>

--- a/etc/opensource-to-commerce/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-commerce/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-commerce/customer-document-groups.xml.dist
+++ b/etc/opensource-to-commerce/customer-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">customer_entity</document>
         <document key="value_id">customer_entity_datetime</document>

--- a/etc/opensource-to-commerce/deltalog.xml.dist
+++ b/etc/opensource-to-commerce/deltalog.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="delta_map">
         <document key="catalog_compare_item_id">catalog_compare_item</document>
         <document key="item_id">cataloginventory_stock_item</document>

--- a/etc/opensource-to-commerce/eav-attribute-groups.xml.dist
+++ b/etc/opensource-to-commerce/eav-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="ignore">
         <attribute type="catalog_product">msrp_enabled</attribute>
         <attribute type="catalog_product">group_price</attribute>

--- a/etc/opensource-to-commerce/eav-document-groups.xml.dist
+++ b/etc/opensource-to-commerce/eav-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/etc/opensource-to-commerce/log-document-groups.xml.dist
+++ b/etc/opensource-to-commerce/log-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document>log_visitor</document>
     </group>

--- a/etc/opensource-to-commerce/map-customer.xml.dist
+++ b/etc/opensource-to-commerce/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/map-document-groups.xml.dist
+++ b/etc/opensource-to-commerce/map-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="destination_documents_update_on_duplicate">
         <document key="query_text,store_id">search_query</document>
         <document key="visitor_id,product_id">report_viewed_product_index</document>

--- a/etc/opensource-to-commerce/map-eav.xml.dist
+++ b/etc/opensource-to-commerce/map-eav.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules />
         <field_rules>

--- a/etc/opensource-to-commerce/map-log.xml.dist
+++ b/etc/opensource-to-commerce/map-log.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/opensource-to-commerce/map-stores.xml.dist
+++ b/etc/opensource-to-commerce/map-stores.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/opensource-to-commerce/map-tier-price.xml.dist
+++ b/etc/opensource-to-commerce/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-commerce/order-grids-document-groups.xml.dist
+++ b/etc/opensource-to-commerce/order-grids-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">sales_flat_order</document>
         <document key="entity_id">sales_flat_order_address</document>

--- a/etc/opensource-to-commerce/settings.xml.dist
+++ b/etc/opensource-to-commerce/settings.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>advanced/modules_disable_output/*</path>

--- a/etc/opensource-to-opensource/1.6.0.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.6.0.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-opensource/1.6.0.0/deltalog.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/deltalog.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="delta_map">
         <document key="catalog_compare_item_id">catalog_compare_item</document>
         <document key="item_id">cataloginventory_stock_item</document>

--- a/etc/opensource-to-opensource/1.6.0.0/map-customer.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.6.1.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-opensource/1.6.1.0/map-customer.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.6.2.0/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-opensource/1.6.2.0/map-customer.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/config.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.1/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.10/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.2/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.3/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.4/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.6/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.7/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.8/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.3.9/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.4.0/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.4.1/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/config.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/config.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/etc/opensource-to-opensource/1.9.4.2/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/etc/opensource-to-opensource/class-map.xml.dist
+++ b/etc/opensource-to-opensource/class-map.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../class-map.xsd">
+<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/class-map.xsd">
     <rename>
         <from>catalogrule/rule_condition_combine</from>
         <to>Magento\CatalogRule\Model\Rule\Condition\Combine</to>

--- a/etc/opensource-to-opensource/customer-attribute-groups.xml.dist
+++ b/etc/opensource-to-opensource/customer-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/etc/opensource-to-opensource/customer-document-groups.xml.dist
+++ b/etc/opensource-to-opensource/customer-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">customer_entity</document>
         <document key="value_id">customer_entity_datetime</document>

--- a/etc/opensource-to-opensource/deltalog.xml.dist
+++ b/etc/opensource-to-opensource/deltalog.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="delta_map">
         <document key="catalog_compare_item_id">catalog_compare_item</document>
         <document key="item_id">cataloginventory_stock_item</document>

--- a/etc/opensource-to-opensource/eav-attribute-groups.xml.dist
+++ b/etc/opensource-to-opensource/eav-attribute-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="ignore">
         <attribute type="catalog_product">msrp_enabled</attribute>
         <attribute type="catalog_product">group_price</attribute>

--- a/etc/opensource-to-opensource/eav-document-groups.xml.dist
+++ b/etc/opensource-to-opensource/eav-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/etc/opensource-to-opensource/log-document-groups.xml.dist
+++ b/etc/opensource-to-opensource/log-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document>log_visitor</document>
     </group>

--- a/etc/opensource-to-opensource/map-customer.xml.dist
+++ b/etc/opensource-to-opensource/map-customer.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/map-document-groups.xml.dist
+++ b/etc/opensource-to-opensource/map-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="destination_documents_update_on_duplicate">
         <document key="query_text,store_id">search_query</document>
         <document key="visitor_id,product_id">report_viewed_product_index</document>

--- a/etc/opensource-to-opensource/map-eav.xml.dist
+++ b/etc/opensource-to-opensource/map-eav.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules />
         <field_rules>

--- a/etc/opensource-to-opensource/map-log.xml.dist
+++ b/etc/opensource-to-opensource/map-log.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/opensource-to-opensource/map-stores.xml.dist
+++ b/etc/opensource-to-opensource/map-stores.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/etc/opensource-to-opensource/map-tier-price.xml.dist
+++ b/etc/opensource-to-opensource/map-tier-price.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/etc/opensource-to-opensource/order-grids-document-groups.xml.dist
+++ b/etc/opensource-to-opensource/order-grids-document-groups.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">sales_flat_order</document>
         <document key="entity_id">sales_flat_order_address</document>

--- a/etc/opensource-to-opensource/settings.xml.dist
+++ b/etc/opensource-to-opensource/settings.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>advanced/modules_disable_output/*</path>

--- a/tests/integration/testsuite/Migration/_files/class-map.xml
+++ b/tests/integration/testsuite/Migration/_files/class-map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/class-map.xsd">
+<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/class-map.xsd">
     <rename>
         <from>customer/customer</from>
         <to>Magento\Customer\Model\ResourceModel\Customer</to>

--- a/tests/integration/testsuite/Migration/_files/config-with-empty-map.xml
+++ b/tests/integration/testsuite/Migration/_files/config-with-empty-map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="migration"/>
     <source>
         <database host="localhost" name="magento1_integration" user="root"/>

--- a/tests/integration/testsuite/Migration/_files/config.xml
+++ b/tests/integration/testsuite/Migration/_files/config.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/tests/integration/testsuite/Migration/_files/customer-attribute-groups.xml
+++ b/tests/integration/testsuite/Migration/_files/customer-attribute-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="customer_entity">
         <attribute>created_in</attribute>
         <attribute>prefix</attribute>

--- a/tests/integration/testsuite/Migration/_files/customer-document-groups.xml
+++ b/tests/integration/testsuite/Migration/_files/customer-document-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document key="entity_id">customer_entity</document>
         <document key="value_id">customer_entity_datetime</document>

--- a/tests/integration/testsuite/Migration/_files/deltalog-empty.xml
+++ b/tests/integration/testsuite/Migration/_files/deltalog-empty.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
         </document_rules>

--- a/tests/integration/testsuite/Migration/_files/deltalog.xml
+++ b/tests/integration/testsuite/Migration/_files/deltalog.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="group1">
         <document key="key">table_with_data</document>
     </group>

--- a/tests/integration/testsuite/Migration/_files/eav-attribute-groups.xml
+++ b/tests/integration/testsuite/Migration/_files/eav-attribute-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="ignore">
         <attribute type="catalog_product">msrp_enabled</attribute>
         <attribute type="catalog_product">group_price</attribute>

--- a/tests/integration/testsuite/Migration/_files/eav-document-groups.xml
+++ b/tests/integration/testsuite/Migration/_files/eav-document-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/tests/integration/testsuite/Migration/_files/ee.config.xml
+++ b/tests/integration/testsuite/Migration/_files/ee.config.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="settings">
         <step title="Settings Step">
             <integrity>Migration\Step\Settings\Integrity</integrity>

--- a/tests/integration/testsuite/Migration/_files/ee.eav-document-groups.xml
+++ b/tests/integration/testsuite/Migration/_files/ee.eav-document-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/tests/integration/testsuite/Migration/_files/ee.map-eav.xml
+++ b/tests/integration/testsuite/Migration/_files/ee.map-eav.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/tests/integration/testsuite/Migration/_files/empty-map.xml
+++ b/tests/integration/testsuite/Migration/_files/empty-map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
     </source>
     <destination>

--- a/tests/integration/testsuite/Migration/_files/list-log.xml.dist
+++ b/tests/integration/testsuite/Migration/_files/list-log.xml.dist
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="source_documents">
         <document>entity_type_id</document>
     </group>

--- a/tests/integration/testsuite/Migration/_files/map-customer.xml
+++ b/tests/integration/testsuite/Migration/_files/map-customer.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/tests/integration/testsuite/Migration/_files/map-eav.xml
+++ b/tests/integration/testsuite/Migration/_files/map-eav.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <transform>

--- a/tests/integration/testsuite/Migration/_files/map-sales.xml
+++ b/tests/integration/testsuite/Migration/_files/map-sales.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/tests/integration/testsuite/Migration/_files/map-stores.xml
+++ b/tests/integration/testsuite/Migration/_files/map-stores.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/tests/integration/testsuite/Migration/_files/map-tier-price-fail.xml
+++ b/tests/integration/testsuite/Migration/_files/map-tier-price-fail.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source/>
     <destination/>
 </map>

--- a/tests/integration/testsuite/Migration/_files/map-tier-price.xml
+++ b/tests/integration/testsuite/Migration/_files/map-tier-price.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <field_rules>
             <ignore>

--- a/tests/integration/testsuite/Migration/_files/map.xml
+++ b/tests/integration/testsuite/Migration/_files/map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <ignore>

--- a/tests/integration/testsuite/Migration/_files/settings.xml
+++ b/tests/integration/testsuite/Migration/_files/settings.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>web/unsecure/base_url</path>

--- a/tests/unit/testsuite/Migration/_files/class-map.xml
+++ b/tests/unit/testsuite/Migration/_files/class-map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/class-map.xsd">
+<classmap xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/class-map.xsd">
     <rename>
         <from>catalog/product_widget_link</from>
         <to>Magento\Catalog\Block\Product\Widget\Link</to>

--- a/tests/unit/testsuite/Migration/_files/eav-attribute-groups.xml
+++ b/tests/unit/testsuite/Migration/_files/eav-attribute-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="ignore">
         <attribute type="catalog_product">msrp_enabled</attribute>
         <attribute type="catalog_product">url_key</attribute>

--- a/tests/unit/testsuite/Migration/_files/eav-document-groups.xml
+++ b/tests/unit/testsuite/Migration/_files/eav-document-groups.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/groups.xsd">
+<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
     <group name="documents">
         <document>eav_attribute_group</document>
         <document>eav_attribute_set</document>

--- a/tests/unit/testsuite/Migration/_files/invalid-config.xml
+++ b/tests/unit/testsuite/Migration/_files/invalid-config.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps/>
     <source>
         <database host="localhost" name="magento1" user="root"/>

--- a/tests/unit/testsuite/Migration/_files/map-invalid.xml
+++ b/tests/unit/testsuite/Migration/_files/map-invalid.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/tests/unit/testsuite/Migration/_files/map.xml
+++ b/tests/unit/testsuite/Migration/_files/map.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/map.xsd">
+<map xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+     xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/map.xsd">
     <source>
         <document_rules>
             <rename>

--- a/tests/unit/testsuite/Migration/_files/settings-invalid.xml
+++ b/tests/unit/testsuite/Migration/_files/settings-invalid.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>path/to/ignore*</path>

--- a/tests/unit/testsuite/Migration/_files/settings.xml
+++ b/tests/unit/testsuite/Migration/_files/settings.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/settings.xsd">
+<settings xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+          xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/settings.xsd">
     <key>
         <ignore>
             <path>path/to/ignore*</path>

--- a/tests/unit/testsuite/Migration/_files/test-config.xml
+++ b/tests/unit/testsuite/Migration/_files/test-config.xml
@@ -5,7 +5,8 @@
  * See COPYING.txt for license details.
  */
 -->
-<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../../../../../etc/config.xsd">
+<config xmlns:xs="http://www.w3.org/2001/XMLSchema-instance"
+        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/config.xsd">
     <steps mode="data">
         <step title="Step1">
             <integrity>Migration\Step\SomeStep\Integrity</integrity>


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

**Issue:**
When developer runs 

```
bin/magento dev:urn-catalog:generate
```

command to generate URNs for PhpStorm it ignores all `*.xsd` files which specified in the `*.xml` configuration files of Data Migration Tool module. 

The reason is: `xs:noNamespaceSchemaLocation` does not contain a reference to module and now it contains a path to a particular `*.xsd` file. For example:

```
...
<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" xs:noNamespaceSchemaLocation="../groups.xsd">
...
```

**Solution:** current pull request fixes mentioned problem by adding `urn:magento:module:Magento_DataMigrationTool` reference to `xs:noNamespaceSchemaLocation` attribute..

```
...
<groups xmlns:xs="http://www.w3.org/2001/XMLSchema-instance" 
        xs:noNamespaceSchemaLocation="urn:magento:module:Magento_DataMigrationTool:etc/groups.xsd">
...
```

<img width="1264" alt="01" src="https://user-images.githubusercontent.com/13585327/62839799-7e358b80-bc98-11e9-9a59-896fa92acdb8.png">


### Fixed Issues (if relevant)
1. magento/data-migration-tool#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Run `dev:urn-catalog:generate` to create a configuration file for PhpStorm "Schemas and DTDs".

2. Open "Schemas and DTDs" in PhpStorm.

**Current result:** `*.xsd` schemes of Data Migration Tool module XML configs which you use in the data migration process have been **not generated**.

**Actual result** `*.xsd` schemes of Data Migration Tool module XML configs which you use in the data migration process should be **generated**.

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 
Thank you!