### PR TITLE
 Detect if entity_id should still be used for opensource-to-commerce and commerce-to-commerce migrations when Magento 2 was installed with Magento_CatalogStaging module disabled

### DIFF
--- a/src/Migration/Handler/Gallery/InsertValueToEntity.php
+++ b/src/Migration/Handler/Gallery/InsertValueToEntity.php
@@ -9,6 +9,7 @@ use Migration\Handler\AbstractHandler;
 use Migration\ResourceModel\Destination;
 use Migration\ResourceModel\Record;
 use Migration\Config;
+use Magento\Framework\Module\ModuleListInterface;
 
 /**
  * Class InsertValueToEntity
@@ -36,15 +37,23 @@ class InsertValueToEntity extends AbstractHandler
     protected $editionMigrate = '';
 
     /**
+     * @var ModuleListInterface
+     */
+    private $moduleList;
+
+    /**
      * @param Destination $destination
      * @param Config $config
+     * @param ModuleListInterface $moduleList
      */
     public function __construct(
         Destination $destination,
-        Config $config
+        Config $config,
+        ModuleListInterface $moduleList
     ) {
         $this->destination = $destination;
         $this->editionMigrate = $config->getOption('edition_migrate');
+        $this->moduleList = $moduleList;
     }
 
     /**
@@ -54,6 +63,7 @@ class InsertValueToEntity extends AbstractHandler
     {
         $this->validate($recordToHandle);
         $entityIdName = $this->editionMigrate == Config::EDITION_MIGRATE_OPENSOURCE_TO_OPENSOURCE
+            || $this->moduleList->has('Magento_CatalogStaging') === false
             ? $this->entityField
             : 'row_id';
         $record['value_id'] = $recordToHandle->getValue($this->field);

--- a/src/Migration/Step/ConfigurablePrices/Helper.php
+++ b/src/Migration/Step/ConfigurablePrices/Helper.php
@@ -49,6 +49,7 @@ class Helper
      * @param Destination $destination
      * @param Source $source
      * @param Config $config
+     * @param ModuleListInterface $moduleList
      */
     public function __construct(
         Destination $destination,

--- a/src/Migration/Step/PostProcessing/Model/AttributeSetLeftoverData.php
+++ b/src/Migration/Step/PostProcessing/Model/AttributeSetLeftoverData.php
@@ -8,6 +8,7 @@ namespace Migration\Step\PostProcessing\Model;
 use Migration\ResourceModel;
 use Migration\Reader\GroupsFactory;
 use Migration\Config;
+use Magento\Framework\Module\ModuleListInterface;
 
 /**
  * Class EavLeftoverData
@@ -18,6 +19,11 @@ class AttributeSetLeftoverData
      * @var ResourceModel\Destination
      */
     private $destination;
+
+    /**
+     * @var ModuleListInterface
+     */
+    private $moduleList;
 
     /**
      * @var \Migration\Reader\Groups
@@ -37,11 +43,13 @@ class AttributeSetLeftoverData
     public function __construct(
         ResourceModel\Destination $destination,
         GroupsFactory $groupsFactory,
-        Config $config
+        Config $config,
+        ModuleListInterface $moduleList
     ) {
         $this->destination = $destination;
         $this->readerDocument = $groupsFactory->create('eav_document_groups_file');
         $this->editionMigrate = $config->getOption('edition_migrate');
+        $this->moduleList = $moduleList;
     }
 
     /**
@@ -56,6 +64,7 @@ class AttributeSetLeftoverData
     {
         $documents = [];
         $entityIdName = $this->editionMigrate == Config::EDITION_MIGRATE_OPENSOURCE_TO_OPENSOURCE
+            || $this->moduleList->has('Magento_CatalogStaging') === false
             ? 'entity_id'
             : 'row_id';
         /** @var \Migration\ResourceModel\Adapter\Mysql $adapter */

--- a/src/Migration/Step/UrlRewrite/Helper.php
+++ b/src/Migration/Step/UrlRewrite/Helper.php
@@ -7,6 +7,7 @@ namespace Migration\Step\UrlRewrite;
 
 use Migration\Reader\MapInterface;
 use Migration\Config;
+use Magento\Framework\Module\ModuleListInterface;
 
 /**
  * Class Helper
@@ -17,6 +18,11 @@ class Helper
      * @var string
      */
     protected $editionMigrate = '';
+
+    /**
+     * @var ModuleListInterface
+     */
+    private $moduleList;
 
     /**
      * Config data of staging module
@@ -31,11 +37,14 @@ class Helper
 
     /**
      * @param Config $config
+     * @param ModuleListInterface $moduleList
      */
     public function __construct(
-        \Migration\Config $config
+        Config $config,
+        ModuleListInterface $moduleList
     ) {
         $this->editionMigrate = $config->getOption('edition_migrate');
+        $this->moduleList = $moduleList;
     }
 
     /**
@@ -70,6 +79,7 @@ class Helper
         if ($this->editionMigrate == Config::EDITION_MIGRATE_OPENSOURCE_TO_OPENSOURCE
             || $resourceType == MapInterface::TYPE_SOURCE
             || !in_array($tableName, $tablesStaging)
+            || $this->moduleList->has('Magento_CatalogStaging') === false
         ) {
             return $fields;
         }


### PR DESCRIPTION
### Description

Detects if `entity_id` should still be used during the Tier Prices step for opensource-to-commerce and commerce-to-commerce migrations that have had Magento installed with the Magento_CatalogStaging module disabled.

### Fixed Issues (if relevant)

When performing a migration from opensource-to-commerce or commerce-to-commerce, one has the option to have their `setup:install` step prior to migration performed with the following parameter:

```
--disable-modules=Magento_BundleStaging\
,Magento_CatalogImportExportStaging\
,Magento_CatalogInventoryStaging\
,Magento_CatalogStaging\
,Magento_CatalogStagingPageBuilder\
,Magento_CatalogUrlRewriteStaging\
,Magento_ConfigurableProductStaging\
,Magento_DownloadableStaging\
,Magento_GroupedProductStaging\
,Magento_ProductVideoStaging\
,Magento_WeeeStaging
```

Doing so, will initially cause the `Map Step` and `Tier Price` steps of the data-migration-tool to have errors regarding `row_id` not being mapped. However a developer has the freedom to copy the appropriate `*.xml.dist` files and modify them accordingly to resolve these issues.

During the Tier Price step however, we have code inside `Migration\Step\ConfigurablePrices\Helper::getDestinationFields()` that always assumes that the `row_id` column will be present if we are performing a migration where opensource is not the destination Magento platform.

This causes the following error during the Tier Price integrity check, that cannot be resolved with simply an XML configuration:

```
[2019-09-28 19:02:51][ERROR]: Destination fields are missing. Document: catalog_product_entity_decimal. Fields: row_id
```

### Manual testing scenarios

1. Install Magento 1.x EE
2. Install Magento Commerce 2.3.2 (with the modules listed in the description above disabled)
3. Copy the appropriate `config.xml.dist` file, modify the database credentials accordingly
4. Copy the corresponding `map-tier-price.xml.dist` file, and remove the `<move>` declarations from the `<source>` node, corresponding to `row_id` (There are two present for a EE 1.14.4.0 to Commerce 2.3.2 migration)
5. Update the `tier_price_map_file` XML node in the `config.xml` file from Step 3 above to reflect the new `map-tier-price.xml` from Step 4 above
6. Run `magento migrate:settings`
7. Run `magento migrate:data`

Following these steps alone, the data migration will still fail due to integrity check failures in the `Map Step`. However this Pull Request is not pertaining to the Map step. What *will* pass however, is the integrity check for the `Tier Price` step.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 