### PR TITLE
Let test classes move to autoload-dev block

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,8 +7,14 @@
         "magento/framework": "*",
         "monolog/monolog": "^1.17"
     },
+    "require-dev": {
+        "phpunit/phpunit"
+    },
     "autoload": {
-        "psr-4": {"Migration\\": ["src/Migration", "tests/unit/testsuite/Migration"]},
+        "psr-4": {"Migration\\": "src/Migration"},
         "files" : ["src/Migration/cli_commands.php", "registration.php"]
+    },
+    "autoload-dev": {
+        "psr-4": {"Migration\\": "tests/unit/testsuite/Migration"}
     }
 }


### PR DESCRIPTION
### Description
- It's proper to let test classes load automatically and defined inside `autoload-dev` block on `composer.json`.

### Manual testing scenarios

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [X] All new or changed code is covered with unit/integration tests (if applicable)
 