### PR TITLE
Add support for eav-attributes-group file in separate module

### DIFF
--- a/src/Migration/Reader/Groups.php
+++ b/src/Migration/Reader/Groups.php
@@ -49,7 +49,7 @@ class Groups
      */
     public function init($groupsFile)
     {
-        $xmlFile = $this->getRootDir() . $groupsFile;
+        $xmlFile = file_exists($groupsFile) ? $groupsFile : $this->getRootDir() . $groupsFile;
         if (!is_file($xmlFile)) {
             throw new Exception('Invalid groups filename: ' . $xmlFile);
         }


### PR DESCRIPTION
### Description
When running the migration tool through the config in a custom module, we cannot load our custom `eav-attribute-groups.xml` because the code from the migration tool will always look for that file in the root of the vendor/magento extension

### Fixed Issues (if relevant)
1. magento/data-migration-tool#768: Allow usage of local eav-attribute-groups.xml file


### Manual testing scenarios
1. Setup a custom module for the migration
2. In your config.xml file, point `eav_attribute_groups_file` to a file in `<your Magento 2 install dir>/app/code/Vendor/Migration/etc/.../eav_attribute_groups.xml`
3. Run the migration
4. bin/magento migrate:data app/code/Vendor/Migration/etc/.../config.xml
5. Your local eav-attributes-group file will be read

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 