### PR TITLE
Fixes for reported issue #774 Delta Rewrites Failure

### DIFF
--- a/src/Migration/Step/UrlRewrite/Version191to2000Delta.php
+++ b/src/Migration/Step/UrlRewrite/Version191to2000Delta.php
@@ -124,7 +124,7 @@ class Version191to2000Delta extends AbstractDelta
     {
         /** @var \Magento\Framework\DB\Adapter\Pdo\Mysql $adapter */
         $adapter = $this->destination->getAdapter()->getSelect()->getAdapter();
-        $adapter->delete(Version191to2000::DESTINATION, "entity_type = 'cms-page'");
+        $adapter->delete($this->destination->addDocumentPrefix(Version191to2000::DESTINATION), "entity_type = 'cms-page'");
         $select = $this->cmsPageRewrites->getSelect();
         $urlRewrites = $this->source->getAdapter()->loadDataFromSelect($select);
         $this->destination->saveRecords(
@@ -148,13 +148,13 @@ class Version191to2000Delta extends AbstractDelta
         ) {
             /** @var \Magento\Framework\DB\Select $select */
             $select = $this->destination->getAdapter()->getSelect();
-            $select->from(Version191to2000::DESTINATION_PRODUCT_CATEGORY)
+            $select->from($this->destination->addDocumentPrefix(Version191to2000::DESTINATION_PRODUCT_CATEGORY),'*')
                 ->where('url_rewrite_id = ?', $record->getValue('url_rewrite_id'))
                 ->where('category_id = ?', $record->getValue('category_id'))
                 ->where('product_id = ?', $record->getValue('product_id'));
             if (!$this->destination->getAdapter()->loadDataFromSelect($select)) {
                 $this->destination->saveRecords(
-                    $this->source->addDocumentPrefix(Version191to2000::DESTINATION_PRODUCT_CATEGORY),
+                    $this->destination->addDocumentPrefix(Version191to2000::DESTINATION_PRODUCT_CATEGORY),
                     [[
                         'url_rewrite_id' => $record->getValue('url_rewrite_id'),
                         'category_id' => $record->getValue('category_id'),


### PR DESCRIPTION

### Description

URLRewrite delta step failed if the source and destination used different prefixes in the database - also failed if there was a database prefix on the destination

Adding the missing document prefixes on 2 lines and correcting source->destination on a 3rd

### Fixed Issues (if relevant)
1. magento/data-migration-tool#774:  Delta Rewrites Failure when database prefixes are used


### Manual testing scenarios

It's a bit of a big scenario!

1. Setup a destination Magento2 with a database prefix different than the source
2. Migrate
3. Wait for changes to have happened in the destination (I had no error immediately after installation)
4. Run delta step

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 