### PR TITLE
Initializing the record transformer before the loop

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -214,6 +214,7 @@ class Data implements StageInterface, RollbackInterface
         $this->destination->backupDocument($destinationDocument->getName());
         $destinationRecords = $this->helper->getDestinationRecords($documentName, [$mappingField]);
         $recordsToSave = $destinationDocument->getRecords();
+        $recordTransformer = $this->helper->getRecordTransformer($sourceDocument, $destinationDocument);
         foreach ($this->helper->getSourceRecords($documentName) as $recordData) {
             /** @var Record $sourceRecord */
             $sourceRecord = $this->factory->create(['document' => $sourceDocument, 'data' => $recordData]);
@@ -227,8 +228,7 @@ class Data implements StageInterface, RollbackInterface
                 $destinationRecordData = $destinationRecord->getDataDefault();
             }
             $destinationRecord->setData($destinationRecordData);
-            $this->helper->getRecordTransformer($sourceDocument, $destinationDocument)
-                ->transform($sourceRecord, $destinationRecord);
+            $recordTransformer->transform($sourceRecord, $destinationRecord);
             $recordsToSave->addRecord($destinationRecord);
         }
         $this->destination->clearDocument($destinationDocument->getName());
@@ -419,8 +419,8 @@ class Data implements StageInterface, RollbackInterface
         $this->destination->backupDocument($destinationDocument->getName());
         $sourceRecords = $this->ignoredAttributes->clearIgnoredAttributes($this->initialData->getAttributes('source'));
         $destinationRecords = $this->initialData->getAttributes('dest');
-
         $recordsToSave = $destinationDocument->getRecords();
+        $recordTransformer = $this->helper->getRecordTransformer($sourceDocument, $destinationDocument);
         foreach ($sourceRecords as $sourceRecordData) {
             /** @var Record $sourceRecord */
             $sourceRecord = $this->factory->create(['document' => $sourceDocument, 'data' => $sourceRecordData]);
@@ -440,9 +440,7 @@ class Data implements StageInterface, RollbackInterface
                 $destinationRecordData = $destinationRecord->getDataDefault();
             }
             $destinationRecord->setData($destinationRecordData);
-
-            $this->helper->getRecordTransformer($sourceDocument, $destinationDocument)
-                ->transform($sourceRecord, $destinationRecord);
+            $recordTransformer->transform($sourceRecord, $destinationRecord);
             $recordsToSave->addRecord($destinationRecord);
         }
 
@@ -476,14 +474,14 @@ class Data implements StageInterface, RollbackInterface
         );
         $this->destination->backupDocument($destinationDocument->getName());
         $recordsToSave = $destinationDocument->getRecords();
+        $recordTransformer = $this->helper->getRecordTransformer($sourceDocument, $destinationDocument);
         foreach ($this->helper->getSourceRecords($sourceDocName) as $sourceRecordData) {
             $sourceRecord = $this->factory->create([
                 'document' => $sourceDocument,
                 'data' => $sourceRecordData
             ]);
             $destinationRecord = $this->factory->create(['document' => $destinationDocument]);
-            $this->helper->getRecordTransformer($sourceDocument, $destinationDocument)
-                ->transform($sourceRecord, $destinationRecord);
+            $recordTransformer->transform($sourceRecord, $destinationRecord);
             $recordsToSave->addRecord($destinationRecord);
         }
 
@@ -790,6 +788,7 @@ class Data implements StageInterface, RollbackInterface
             $recordsToSave = $destinationDocument->getRecords();
             $sourceRecords = $this->ignoredAttributes
                 ->clearIgnoredAttributes($this->helper->getSourceRecords($documentName));
+            $recordTransformer = $this->helper->getRecordTransformer($sourceDocument, $destinationDocument);
             foreach ($sourceRecords as $recordData) {
                 /** @var Record $sourceRecord */
                 $sourceRecord = $this->factory->create(['document' => $sourceDocument, 'data' => $recordData]);
@@ -805,8 +804,7 @@ class Data implements StageInterface, RollbackInterface
                     $destinationRecordData = $destinationRecord->getDataDefault();
                 }
                 $destinationRecord->setData($destinationRecordData);
-                $this->helper->getRecordTransformer($sourceDocument, $destinationDocument)
-                    ->transform($sourceRecord, $destinationRecord);
+                $recordTransformer->transform($sourceRecord, $destinationRecord);
                 $recordsToSave->addRecord($destinationRecord);
             }
             $this->destination->clearDocument($destinationDocument->getName());

--- a/src/Migration/Step/TierPrice/Data.php
+++ b/src/Migration/Step/TierPrice/Data.php
@@ -107,25 +107,25 @@ class Data implements StageInterface
             $this->logger->debug('migrating', ['table' => $sourceDocName]);
             $this->progress->start($this->source->getRecordsCount($sourceDocName), LogManager::LOG_LEVEL_DEBUG);
 
+            $destinationName = $this->helper->getMappedDocumentName($sourceDocName, MapInterface::TYPE_SOURCE);
+            $destDocument = $this->destination->getDocument($destinationName);
+            $sourceDocument = $this->source->getDocument($sourceDocName);
+
+            /** @var \Migration\RecordTransformer $recordTransformer */
+            $recordTransformer = $this->recordTransformerFactory->create(
+                [
+                    'sourceDocument' => $sourceDocument,
+                    'destDocument' => $destDocument,
+                    'mapReader' => $this->map
+                ]
+            );
+            $recordTransformer->init();
+
             while (!empty($items = $this->source->getRecords($sourceDocName, $pageNumber))) {
                 $this->progress->advance(LogManager::LOG_LEVEL_INFO);
 
                 $pageNumber++;
-                $destinationName = $this->helper->getMappedDocumentName($sourceDocName, MapInterface::TYPE_SOURCE);
-                $destDocument = $this->destination->getDocument($destinationName);
                 $destinationRecords = $destDocument->getRecords();
-
-                $sourceDocument = $this->source->getDocument($sourceDocName);
-                /** @var \Migration\RecordTransformer $recordTransformer */
-                $recordTransformer = $this->recordTransformerFactory->create(
-                    [
-                        'sourceDocument' => $sourceDocument,
-                        'destDocument' => $destDocument,
-                        'mapReader' => $this->map
-                    ]
-                );
-                $recordTransformer->init();
-
                 foreach ($items as $recordData) {
                     $this->progress->advance(LogManager::LOG_LEVEL_DEBUG);
 


### PR DESCRIPTION
### Description
When migrating data in the **EAV Step**, the record transformer instance is initialized inside the records loop. This leads to the fact that for each record transformer, new instances of handlers are initialized. Since some handlers make a query to the db and store the result in their properties, it turns out that each new handler instance will execute this query.

A similar issue is present in the **Tier Price Step**, only the record transformer is initialized inside the pages loop.

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Add breakpoint at `\Migration\Handler\EavAttribute\ApplyTo::checkIfUserDefined()` this handler will transform `catalog_eav_attribute.apply_to` field
2. Run migrating of the `EAV Step`
3. Catch multiple duplicate unnecessary queries to the db per table transformation

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 