### PR TITLE
Pass the count mode argument as const instead of int

### DIFF
--- a/src/Migration/App/SetupDeltaLog.php
+++ b/src/Migration/App/SetupDeltaLog.php
@@ -67,7 +67,7 @@ class SetupDeltaLog implements StageInterface
         $countDeltaDocumentsCreated = 0;
         $deltaLogs = [];
         $deltaLogsGroups = $this->getGroupsReader()->getGroups();
-        $this->progress->start(count($deltaLogsGroups, 1) - count($deltaLogsGroups));
+        $this->progress->start(count($deltaLogsGroups, COUNT_RECURSIVE) - count($deltaLogsGroups));
         /**
          * Eliminate duplicates
          */


### PR DESCRIPTION
### Description
For more convenience we can pass predefined const [COUNT_RECURSIVE](https://www.php.net/manual/en/function.count.php#refsect1-function.count-parameters) instead of int value **1**

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 