### PR TITLE
Wildcard must represent zero or more characters

### DIFF
--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2023,9 +2014,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2209,7 +2197,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2356,9 +2344,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2402,12 +2387,6 @@
             </ignore>
             <ignore>
                 <document>tax_order_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2797,10 +2776,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3423,12 +3399,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3475,12 +3445,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2023,9 +2014,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2209,7 +2197,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2356,9 +2344,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2402,12 +2387,6 @@
             </ignore>
             <ignore>
                 <document>tax_order_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2797,10 +2776,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3423,12 +3399,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3475,12 +3445,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2194,7 +2185,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2341,9 +2332,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2387,12 +2375,6 @@
             </ignore>
             <ignore>
                 <document>tax_order_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2782,10 +2764,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3408,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3460,12 +3433,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2341,9 +2332,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2375,12 +2363,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2770,10 +2752,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3381,12 +3360,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3433,12 +3406,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2194,7 +2185,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2341,9 +2332,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2375,12 +2363,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2770,10 +2752,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3378,12 +3357,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3430,12 +3403,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2146,7 +2137,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2290,16 +2281,7 @@
                 <document>support_report</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>salesrule_coupon_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2692,10 +2674,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3207,12 +3186,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3259,12 +3232,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2146,7 +2137,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2290,16 +2281,7 @@
                 <document>support_report</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>salesrule_coupon_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2692,10 +2674,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3231,12 +3210,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3283,12 +3256,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2146,7 +2137,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2290,16 +2281,7 @@
                 <document>support_report</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>salesrule_coupon_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2692,10 +2674,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3231,12 +3210,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3283,12 +3256,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1959,9 +1950,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2145,7 +2133,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2679,10 +2667,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3154,12 +3139,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3206,12 +3185,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1959,9 +1950,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2145,7 +2133,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2679,10 +2667,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3154,12 +3139,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3206,12 +3185,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -458,9 +452,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1959,9 +1950,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2145,7 +2133,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2679,10 +2667,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3154,12 +3139,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3206,12 +3185,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1965,9 +1956,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2151,7 +2139,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2685,10 +2673,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3166,12 +3151,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3218,12 +3197,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1965,9 +1956,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2151,7 +2139,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2685,10 +2673,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3157,12 +3142,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3209,12 +3188,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1965,9 +1956,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2151,7 +2139,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2685,10 +2673,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3157,12 +3142,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3209,12 +3188,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1973,9 +1964,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2159,7 +2147,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2687,10 +2675,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3159,12 +3144,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3211,12 +3190,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2004,9 +1995,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2190,7 +2178,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2724,10 +2712,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3208,12 +3193,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3260,12 +3239,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2004,9 +1995,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2190,7 +2178,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2724,10 +2712,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3208,12 +3193,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3260,12 +3239,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2010,9 +2001,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2196,7 +2184,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2730,10 +2718,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3214,12 +3199,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3266,12 +3245,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2010,9 +2001,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2196,7 +2184,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2730,10 +2718,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3214,12 +3199,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3266,12 +3245,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2010,9 +2001,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2196,7 +2184,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2730,10 +2718,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3214,12 +3199,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3266,12 +3245,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2022,9 +2013,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>
@@ -2208,7 +2196,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2742,10 +2730,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3226,12 +3211,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3278,12 +3257,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2161,7 +2152,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2695,10 +2686,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3177,12 +3165,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2316,7 +2307,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2850,10 +2841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3332,12 +3320,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2157,7 +2148,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2691,10 +2682,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3173,12 +3161,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2157,7 +2148,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2691,10 +2682,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3173,12 +3161,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2310,7 +2301,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2844,10 +2835,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3326,12 +3314,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2310,7 +2301,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2844,10 +2835,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3326,12 +3314,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2310,7 +2301,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2844,10 +2835,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3326,12 +3314,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2310,7 +2301,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2844,10 +2835,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3326,12 +3314,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2316,7 +2307,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2850,10 +2841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3332,12 +3320,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2316,7 +2307,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2850,10 +2841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3332,12 +3320,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2319,7 +2310,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2853,10 +2844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3335,12 +3323,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2319,7 +2310,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2853,10 +2844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3335,12 +3323,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2319,7 +2310,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2853,10 +2844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3335,12 +3323,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -145,9 +145,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -155,9 +152,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -464,9 +458,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -2319,7 +2310,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2853,10 +2844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3335,12 +3323,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -434,9 +428,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1676,7 +1667,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1988,9 +1979,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2034,12 +2022,6 @@
             </ignore>
             <ignore>
                 <document>tax_order_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2408,10 +2390,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3587,12 +3566,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3621,12 +3594,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -434,9 +428,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1697,7 +1688,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2009,9 +2000,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2043,12 +2031,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2417,10 +2399,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3626,12 +3605,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3660,12 +3633,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -434,9 +428,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1697,7 +1688,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2009,9 +2000,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -2043,12 +2031,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -2417,10 +2399,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3623,12 +3602,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3657,12 +3630,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3424,12 +3409,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3458,12 +3437,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3424,12 +3409,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3458,12 +3437,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3424,12 +3409,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3458,12 +3437,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3402,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3436,12 +3415,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -422,9 +416,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1429,9 +1420,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1648,7 +1636,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2323,10 +2311,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3399,12 +3384,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3433,12 +3412,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3402,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3436,12 +3415,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3402,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3436,12 +3415,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3402,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3436,12 +3415,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1432,9 +1423,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1651,7 +1639,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2326,10 +2314,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3402,12 +3387,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3436,12 +3415,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1446,9 +1437,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1665,7 +1653,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2346,10 +2334,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3428,12 +3413,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3462,12 +3441,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1446,9 +1437,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1665,7 +1653,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2346,10 +2334,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3428,12 +3413,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3462,12 +3441,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1446,9 +1437,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1665,7 +1653,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2346,10 +2334,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3428,12 +3413,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3462,12 +3441,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1446,9 +1437,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1665,7 +1653,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2346,10 +2334,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3428,12 +3413,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3462,12 +3441,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1446,9 +1437,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1665,7 +1653,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2346,10 +2334,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3428,12 +3413,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3462,12 +3441,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1458,9 +1449,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1677,7 +1665,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2358,10 +2346,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3440,12 +3425,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3474,12 +3453,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1458,9 +1449,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1677,7 +1665,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2358,10 +2346,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3440,12 +3425,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3474,12 +3453,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2313,10 +2304,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3393,12 +3381,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1458,9 +1449,6 @@
                 <document>signifyd_case</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1677,7 +1665,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2358,10 +2346,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3440,12 +3425,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -3474,12 +3453,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1635,7 +1626,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2313,10 +2304,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3393,12 +3381,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1638,7 +1629,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1638,7 +1629,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1638,7 +1629,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1638,7 +1629,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -2316,10 +2307,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -3396,12 +3384,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -124,9 +124,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -134,9 +131,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -428,9 +422,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1528,7 +1519,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1696,9 +1687,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -1742,12 +1730,6 @@
             </ignore>
             <ignore>
                 <document>tax_order_aggregated_updated</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -1870,10 +1852,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2305,12 +2284,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2339,12 +2312,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -124,9 +124,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -134,9 +131,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -416,9 +410,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1540,7 +1531,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1708,9 +1699,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -1742,12 +1730,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -1870,10 +1852,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2326,12 +2305,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2360,12 +2333,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -124,9 +124,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -134,9 +131,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -416,9 +410,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1540,7 +1531,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1708,9 +1699,6 @@
                 <document>captcha_log</document>
             </ignore>
             <ignore>
-                <document>catalog_product_index_group_price</document>
-            </ignore>
-            <ignore>
                 <document>catalogrule_customer_group</document>
             </ignore>
             <ignore>
@@ -1742,12 +1730,6 @@
             </ignore>
             <ignore>
                 <document>salesrule_website</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_index_price*</document>
             </ignore>
             <ignore>
                 <document>reporting_module_status</document>
@@ -1870,10 +1852,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2323,12 +2302,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2357,12 +2330,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1791,10 +1779,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2169,12 +2154,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2203,12 +2182,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1791,10 +1779,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2169,12 +2154,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2203,12 +2182,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1791,10 +1779,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2169,12 +2154,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2203,12 +2182,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1791,10 +1779,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2147,12 +2132,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2181,12 +2160,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -422,9 +416,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1293,9 +1284,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1503,7 +1491,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1788,10 +1776,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2144,12 +2129,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2178,12 +2157,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1797,10 +1785,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2153,12 +2138,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2187,12 +2166,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1797,10 +1785,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2153,12 +2138,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2187,12 +2166,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1797,10 +1785,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2153,12 +2138,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2187,12 +2166,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1296,9 +1287,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1506,7 +1494,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1797,10 +1785,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2153,12 +2138,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2187,12 +2166,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1310,9 +1301,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1520,7 +1508,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1811,10 +1799,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2173,12 +2158,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2207,12 +2186,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1310,9 +1301,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1520,7 +1508,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1811,10 +1799,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2173,12 +2158,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2207,12 +2186,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1310,9 +1301,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1520,7 +1508,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1811,10 +1799,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2173,12 +2158,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2207,12 +2186,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1310,9 +1301,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1520,7 +1508,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1811,10 +1799,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2173,12 +2158,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2207,12 +2186,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1310,9 +1301,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1520,7 +1508,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1811,10 +1799,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2173,12 +2158,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2207,12 +2186,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1322,9 +1313,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1532,7 +1520,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1823,10 +1811,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2185,12 +2170,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2219,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1322,9 +1313,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1532,7 +1520,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1823,10 +1811,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2185,12 +2170,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2219,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -133,9 +133,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -143,9 +140,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -425,9 +419,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1349,9 +1340,6 @@
     <destination>
         <document_rules>
             <ignore>
-                <document>catalog_product_index_price*</document>
-            </ignore>
-            <ignore>
                 <document>customer_entity</document>
             </ignore>
             <ignore>
@@ -1559,7 +1547,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1838,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2212,12 +2197,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2248,12 +2227,6 @@
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
             </ignore>
             <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>
             </ignore>
             <ignore>
@@ -2282,12 +2255,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1559,7 +1550,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1850,10 +1841,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2210,12 +2198,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1562,7 +1553,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1853,10 +1844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2213,12 +2201,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1562,7 +1553,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1853,10 +1844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2213,12 +2201,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1562,7 +1553,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1853,10 +1844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2213,12 +2201,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -139,9 +139,6 @@
                 <document>catalog_category_anc_products_index_tmp</document>
             </ignore>
             <ignore>
-                <document>catalog_category_flat_cl</document>
-            </ignore>
-            <ignore>
                 <document>catalog_product_index*</document>
             </ignore>
             <ignore>
@@ -149,9 +146,6 @@
             </ignore>
             <ignore>
                 <document>catalog_product_enabled_index</document>
-            </ignore>
-            <ignore>
-                <document>catalog_product_flat_cl</document>
             </ignore>
             <ignore>
                 <document>cataloginventory_stock_status</document>
@@ -431,9 +425,6 @@
             </ignore>
             <ignore>
                 <document>catalog_category_flat*</document>
-            </ignore>
-            <ignore>
-                <document>catalog_category_flat_store_*</document>
             </ignore>
             <ignore>
                 <document>googleoptimizer_code</document>
@@ -1562,7 +1553,7 @@
                 <document>sequence_order_*</document>
             </ignore>
             <ignore>
-                <document>sequence_shipment*</document>
+                <document>sequence_shipment_*</document>
             </ignore>
             <ignore>
                 <document>sequence_rma_item_*</document>
@@ -1853,10 +1844,7 @@
                 <document>inventory_source_stock_link</document>
             </ignore>
             <ignore>
-                <document>inventory_stock</document>
-            </ignore>
-            <ignore>
-                <document>inventory_stock_*</document>
+                <document>inventory_stock*</document>
             </ignore>
             <ignore>
                 <document>inventory_geoname</document>
@@ -2213,12 +2201,6 @@
             </ignore>
             <ignore>
                 <datatype>catalog_product_bundle_price_index.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_price.customer_group_id</datatype>
-            </ignore>
-            <ignore>
-                <datatype>catalog_product_index_tier_price.customer_group_id</datatype>
             </ignore>
             <ignore>
                 <datatype>catalogrule_customer_group.customer_group_id</datatype>

--- a/src/Migration/Reader/Map.php
+++ b/src/Migration/Reader/Map.php
@@ -151,7 +151,7 @@ class Map implements MapInterface
         $result = ($map->length > 0);
         if (!$result) {
             foreach ($this->getWildcards($type) as $documentWildCard) {
-                $regexp = '/^' . str_replace('*', '.+', $documentWildCard->nodeValue) . '/';
+                $regexp = '/^' . str_replace('*', '.*', $documentWildCard->nodeValue) . '/';
                 $result = preg_match($regexp, $document) > 0;
                 if ($result === true) {
                     break;

--- a/tests/unit/testsuite/Migration/Reader/MapTest.php
+++ b/tests/unit/testsuite/Migration/Reader/MapTest.php
@@ -36,7 +36,10 @@ class MapTest extends \PHPUnit\Framework\TestCase
     public function testHasDocument()
     {
         $this->assertTrue($this->map->isDocumentMapped('source-document', MapInterface::TYPE_SOURCE));
+        $this->assertFalse($this->map->isDocumentMapped('source-document-ignored', MapInterface::TYPE_SOURCE));
+        $this->assertFalse($this->map->isDocumentMapped('source-document-ignored-wildcard', MapInterface::TYPE_SOURCE));
         $this->assertFalse($this->map->isDocumentMapped('dest-document-ignored', MapInterface::TYPE_DEST));
+        $this->assertFalse($this->map->isDocumentMapped('dest-document-ignored-wildcard', MapInterface::TYPE_DEST));
         $this->assertFalse($this->map->isDocumentMapped('non-existent-document', MapInterface::TYPE_SOURCE));
     }
 

--- a/tests/unit/testsuite/Migration/_files/map.xml
+++ b/tests/unit/testsuite/Migration/_files/map.xml
@@ -14,9 +14,6 @@
                 <to>dest-document</to>
             </rename>
             <ignore>
-                <document>source-document-ignored</document>
-            </ignore>
-            <ignore>
                 <document>source-document-ignored*</document>
             </ignore>
         </document_rules>
@@ -54,9 +51,6 @@
     </source>
     <destination>
         <document_rules>
-            <ignore>
-                <document>dest-document-ignored</document>
-            </ignore>
             <ignore>
                 <document>dest-document-ignored*</document>
             </ignore>


### PR DESCRIPTION
### Description
To ignore all the extension tables, we must be able to set only one wildcard rule. For example, to ignore all the tables for the blog by aheadworks, we must specify two rules for ignoring: `aw_blog` and `aw_blog*`, since this module has a table `aw_blog` and has tables `aw_blog_cat`, `aw_blog_cat_store` and so on, and the `aw_blog*` rule is cast to `/^aw_blog.+/` regexp. This fix causes the regular expression to look like `/^aw_blog.*/` and allows us to ignore such tables by specifying just one wildcard rule

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 