### PR TITLE
Improve informational message

### DIFF
--- a/src/Migration/Step/Eav/Integrity/AttributeGroupNames.php
+++ b/src/Migration/Step/Eav/Integrity/AttributeGroupNames.php
@@ -85,10 +85,11 @@ class AttributeGroupNames
         $groupNamesToValidate = array_keys($this->groupNameToCodeMap->getMap('catalog_product'));
         foreach ($attributeGroupsOfCatalogProduct as $attributeSetId => $groupNames) {
             if (!empty(array_diff($groupNamesToValidate, $groupNames))) {
-                $error = 'The product attribute set "%s" does not contain all required attribute group names "%s"';
+                $error = 'The product attribute set "%s" (ID: %s) does not contain all required attribute group names "%s"';
                 $error = sprintf(
                     $error,
                     $attributeSetsOfCatalogProduct[$attributeSetId],
+                    $attributeSetId,
                     implode(', ', $groupNamesToValidate)
                 );
                 $errorDetails['document'] = $this->attributeGroupDocument;


### PR DESCRIPTION
### Description
This commit improves the informational message for the person who performs migration.

### Manual testing scenarios
You have to run migration with multiple attribute sets. If your attribute sets have the same names in M1 then you won't be able to recognize them by name from this error message. I'm adding the ID to make it all clear.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [-] All new or changed code is covered with unit/integration tests (if applicable)
 