### PR TITLE
fix error of enterprise-tables not being present in opensource database

### DIFF
--- a/etc/opensource-to-commerce/deltalog.xml.dist
+++ b/etc/opensource-to-commerce/deltalog.xml.dist
@@ -90,9 +90,6 @@
         <document key="title_id">downloadable_link_title</document>
         <document key="sample_id">downloadable_sample</document>
         <document key="title_id">downloadable_sample_title</document>
-        <document key="value_id">enterprise_giftcard_amount</document>
-        <document key="rule_id">enterprise_targetrule</document>
-        <document key="rule_id,product_id">enterprise_targetrule_product</document>
         <document key="link_id">catalog_product_super_link</document>
         <document key="product_super_attribute_id">catalog_product_super_attribute</document>
         <document key="value_id">catalog_product_super_attribute_label</document>


### PR DESCRIPTION
### Description
Without this change the Data Migration Tool expects to find three enterprise-tables within the database of a Magento community (open source) installation when migrating to Magento 2 Commerce.
As those tables are not present the migration first triggers a warning an then fails completely later on.

### Steps to reproduce (example)
- Magento 2.3.4 Commerce-installation to migrate to
- Release 2.3.4 of Data Migration Tool installed
- Magento 1.9.3.9 Community installation to migrate from
- Perform settings migration (no problems occur during this step)
- Perform data migration

### Result without the change
- _[stage: setup triggers][step: Stage]_ causes _[WARNING]: Some of the delta log tables were not created. Expected:106. Actual:103_ Debugging reveled that the three enterprise tables are the ones no triggers could be added for
- _[stage: data migration][step: PostProcessing Step]_ fails the migration due to a SQL-error: 
> SQLSTATE[42S02]: Base table or view not found: 1146 Table 'xyz_m1_plain.enterprise_giftcard_amount' doesn't exist, query was: SELECT COUNT(*) FROM `enterprise_giftcard_amount` 

### Result with the change
- Migration completes successfully (no warning, no errors)
