### PR TITLE
Fixed file path issue after override class-map.xml file

### DIFF
--- a/src/Migration/Reader/ClassMap.php
+++ b/src/Migration/Reader/ClassMap.php
@@ -68,7 +68,7 @@ class ClassMap
     {
         $mapFile = $this->config->getOption(self::MAP_FILE_OPTION);
         $rootDir = dirname(dirname(dirname(__DIR__))) . DIRECTORY_SEPARATOR;
-        $configFile = $rootDir . $mapFile;
+        $configFile = file_exists($mapFile) ? $mapFile : $rootDir . $mapFile;
         if (!is_file($configFile)) {
             throw new Exception('Invalid map filename: ' . $configFile);
         }


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/data-migration-tool#805: Data migration tool: class-map.xml file overridden issue in csutom module

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Created a new module
2. Override class-map.xml file to the new module
3. Run data migration command

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 