### PR TITLE
fix(mysql): independently set ssl_ca, ssl_cert, and ssl_key

### DIFF
--- a/src/Migration/ResourceModel/Adapter/Pdo/MysqlBuilder.php
+++ b/src/Migration/ResourceModel/Adapter/Pdo/MysqlBuilder.php
@@ -85,12 +85,20 @@ class MysqlBuilder
         $config['password'] = !empty($resource['password']) ? $resource['password'] : '';
         if (!empty($resource['port'])) {
             $config['host'] = $config['host'] . ':' . $resource['port'];
-        }
-        if (isset($resource['ssl_key']) && isset($resource['ssl_cert']) && isset($resource['ssl_ca'])) {
+	}
+	
+	if (isset($resource['ssl_key'])) {
             $config['driver_options'][\PDO::MYSQL_ATTR_SSL_KEY] = $resource['ssl_key'];
+	}
+
+        if(isset($resource['ssl_cert'])){
             $config['driver_options'][\PDO::MYSQL_ATTR_SSL_CERT] = $resource['ssl_cert'];
+	}
+
+        if(isset($resource['ssl_ca'])){
             $config['driver_options'][\PDO::MYSQL_ATTR_SSL_CA] = $resource['ssl_ca'];
-        }
+	}
+
         return $config;
     }
 


### PR DESCRIPTION
### Description
This PR allows developers to indepdently set `ssl_ca`, `ssl_cert` and `ssl_key`.

Not all SSL connections require a key, cert and CA file. For instance, Azure Database for MySQL enables SSL connections with only a CA file. See: https://docs.microsoft.com/en-us/azure/mysql/howto-configure-ssl This commit allows developers to port M1 databases out of Azure Database for MySQL to another environment without compromising security.

### Fixed Issues (if relevant)
N/A

### Manual testing scenarios
1. Try to create a connection to an Azure Database for MySQL by setting `ssl_ca` in the database config. 
2. Run `bin/magento migrate:settings`
3. Fail with ` SQLSTATE[HY000] [9002] SSL connection is required. Please specify SSL options and retry.`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 