### PR TITLE
Fixes undefined index error and adds new helper method (#825)

### DIFF
--- a/src/Migration/Step/Eav/Helper.php
+++ b/src/Migration/Step/Eav/Helper.php
@@ -114,7 +114,7 @@ class Helper
                 foreach ($keyFields as $keyField) {
                     $key[] = $row[$keyField];
                 }
-                $data[implode('-', $key)] = $row;
+                $data[$this->getKeyFromFields(...$key)] = $row;
             } else {
                 $data[] = $row;
             }
@@ -140,7 +140,7 @@ class Helper
                 foreach ($keyFields as $keyField) {
                     $key[] = $row[$keyField];
                 }
-                $data[implode('-', $key)] = $row;
+                $data[$this->getKeyFromFields(...$key)] = $row;
             } else {
                 $data[] = $row;
             }
@@ -199,6 +199,21 @@ class Helper
             }
         }
         return $attributeCodes;
+    }
+
+    /**
+     * Returns a string that represents a key in an array returned from `Migration\Step\Eav\Helper::getSourceRecords()`
+     * or `Migration\Step\Eav\Helper::getDestinationRecords()` whenever `$keyFields` is provided
+     *
+     * For example, calling `getSourceRecords()` for `eav_attribute_set` with `entity_type_id` and `attribute_set_name`
+     * as your key fields, would return an array with keys like `1-Default`, `2-Migration_Default`, etc.
+     *
+     * @param mixed[] $fields
+     * @return string
+     */
+    public function getKeyFromFields(...$fields)
+    {
+        return implode('-', $fields);
     }
 
     /**

--- a/src/Migration/Step/Eav/Model/Data.php
+++ b/src/Migration/Step/Eav/Model/Data.php
@@ -279,13 +279,19 @@ class Data
     {
         $defaultAttributes = [];
         foreach ($this->initialData->getAttributes('dest') as $id => $attribute) {
-            $defaultAttributes[$id] = $attribute['attribute_code'] . '-' . $attribute['entity_type_id'];
+            $defaultAttributes[$id] = $this->helper->getKeyFromFields(
+                $attribute['attribute_code'],
+                $attribute['entity_type_id']
+            );
         }
         $sourceAttributes = $this->ignoredAttributes->clearIgnoredAttributes(
             $this->initialData->getAttributes('source')
         );
         foreach ($sourceAttributes as $id => $attribute) {
-            $sourceAttributes[$id] = $attribute['attribute_code'] . '-' . $attribute['entity_type_id'];
+            $sourceAttributes[$id] = $this->helper->getKeyFromFields(
+                $attribute['attribute_code'],
+                $attribute['entity_type_id']
+            );
         }
         return array_keys(array_diff($sourceAttributes, $defaultAttributes));
     }

--- a/tests/unit/testsuite/Migration/Step/Eav/HelperTest.php
+++ b/tests/unit/testsuite/Migration/Step/Eav/HelperTest.php
@@ -128,6 +128,14 @@ class HelperTest extends \PHPUnit\Framework\TestCase
     /**
      * @return void
      */
+    public function testGetKeyFromFields()
+    {
+        $this->assertEquals('1-Default', $this->helper->getKeyFromFields(1, 'Default'));
+    }
+
+    /**
+     * @return void
+     */
     public function testGetSourceRecordsCount()
     {
         $this->source->expects($this->once())->method('getRecordsCount')->with('some_document')


### PR DESCRIPTION
### Description
- Adds `Migration\Step\Eav\Helper::getKeyFromFields()` to consolidate the functionality used to assemble a field key for a row, giving the action semantic meaning and making the code a little DRYer
- Fixes the undefined index error that's thrown from `Migration\Step\Eav\Data::createMapAttributeSetIds()`, by adding a new property `$mapNewAttributeSetsToSourceKeys` which maintains a mapping of source to destination field keys (e.g. `1-Default => 1-Migration_Default`)

### Fixed Issues (if relevant)
1. magento/data-migration-tool#825: Undefined index: 1-Default in Migration\Step\Eav\Data on line 624

### Manual testing scenarios
1. Run the data migration tool for a migration of Magento 1.14.4.5 to 2.3.5-p1
2. Ensure that an exception representing an undefined index notice isn't thrown from `Migration\Step\Eav\Data::createMapAttributeSetIds()`

Further information can be found in #825.

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)
 