### PR TITLE
If no custom entity attributes exist then return without processing

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -479,6 +479,9 @@ class Data implements StageInterface, RollbackInterface
         );
         $recordsToSave = $destinationDocument->getRecords();
         $customAttributeIds = $this->modelData->getCustomAttributeIds();
+        if (empty($customAttributeIds)) {
+            return;
+        }
         $customEntityAttributes = $this->source->getRecords(
             $sourceDocName,
             0,


### PR DESCRIPTION
### Description
When  there are no CustomEntityAttributes to migrate then an invalid SQL statement is produced and the migration dies.
Adds a defensive if statement to avoid this error and return early

### Fixed Issues (if relevant)
1. n/a

### Manual testing scenarios
1. Migrate from a Magento 1.9.2.1 which has no custom entity attributes (aside from those in the ignore list)
2. Run the data migration step of the migration tool

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [x] All new or changed code is covered with unit/integration tests (if applicable)

 