### PR TITLE
Add support for non-default attribute set groups

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -496,7 +496,43 @@ class Data implements StageInterface, RollbackInterface
         );
         foreach ($customEntityAttributes as $record) {
             if (!isset($this->mapAttributeGroupIdsSourceDest[$record['attribute_group_id']])) {
-                continue;
+                // create the group id
+                $this->migrateAttributeGroups([$record['attribute_group_id']]);
+
+                /*$productAttributeSetIds = array_keys($this->modelData->getAttributeSets(
+                    $record['entity_type_id'],
+                    ModelData::ATTRIBUTE_SETS_NONE_DEFAULT
+                ));*/
+
+                $attributeGroupsDestination = $this->helper->getDestinationRecords(
+                    'eav_attribute_group',
+                    ['attribute_group_id']
+                );
+                $attributeGroupsSource = $this->helper->getSourceRecords(
+                    'eav_attribute_group',
+                    ['attribute_group_id']
+                );
+
+                foreach ($attributeGroupsSource as $idSource => $recordSource) {
+                    $sourceAttributeGroupName = $recordSource['attribute_group_name'];
+                    /*if (in_array($recordSource['attribute_set_id'], $productAttributeSetIds)) {
+                        $sourceAttributeGroupName = str_replace(
+                            array_keys($this->mapProductAttributeGroupNamesSourceDest),
+                            $this->mapProductAttributeGroupNamesSourceDest,
+                            $recordSource['attribute_group_name']
+                        );
+                    }*/
+                    $sourceKey = $recordSource['attribute_set_id'] . ' ' . $sourceAttributeGroupName;
+                    foreach ($attributeGroupsDestination as $idDestination => $recordDestination) {
+                        $destinationKey = $recordDestination['attribute_set_id']
+                            . ' '
+                            . $recordDestination['attribute_group_name'];
+                        if ($sourceKey == $destinationKey) {
+                            $this->mapAttributeGroupIdsSourceDest[$recordSource['attribute_group_id']] =
+                                $recordDestination['attribute_group_id'];
+                        }
+                    }
+                }
             }
             $record['sort_order'] = $this->getCustomAttributeSortOrder($record);
             $record['attribute_group_id'] = $this->mapAttributeGroupIdsSourceDest[$record['attribute_group_id']];


### PR DESCRIPTION
### Description
See: https://github.com/magento/data-migration-tool/issues/847

### Fixed Issues (if relevant)
1. magento/data-migration-tool#847: Data Migration Tool does not support migrating non-default entity-types and/or attribute set groups

### Manual testing scenarios
See: https://github.com/magento/data-migration-tool/issues/847

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 