### PR TITLE
Data Migration Tool Release 2.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+2.4.2
+=============
+* Added support for versions:
+
+    * Magento Open Source: 2.4.2
+    * Magento Commerce: 2.4.2
+
+* Fixed bugs:
+
+    * Add support for non-default attribute set groups
+    * Time difference issue
+
 2.4.1
 =============
 * Added support for versions:

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/data-migration-tool",
     "description": "Migration Tool",
-    "version": "2.4.1",
+    "version": "2.4.2",
     "require": {
         "symfony/console": "~4.4.0",
         "magento/framework": "*",

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2582,6 +2582,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -3067,6 +3067,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -1918,6 +1918,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2582,6 +2582,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2672,6 +2672,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2582,6 +2582,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -3067,6 +3067,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -1918,6 +1918,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2582,6 +2582,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2672,6 +2672,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2570,6 +2570,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2660,6 +2660,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -1918,6 +1918,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3446,6 +3452,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2570,6 +2570,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -3055,6 +3055,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2558,6 +2558,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2648,6 +2648,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2558,6 +2558,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -3043,6 +3043,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -1918,6 +1918,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3419,6 +3425,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2558,6 +2558,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2648,6 +2648,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2558,6 +2558,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -3043,6 +3043,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -1918,6 +1918,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3416,6 +3422,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2965,6 +2965,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -1876,6 +1876,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3239,6 +3245,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2570,6 +2570,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2965,6 +2965,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -1876,6 +1876,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3266,6 +3272,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2570,6 +2570,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2965,6 +2965,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -1876,6 +1876,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3266,6 +3272,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2570,6 +2570,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2480,6 +2480,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2939,6 +2939,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -1860,6 +1860,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3198,6 +3204,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2563,6 +2563,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2939,6 +2939,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -1860,6 +1860,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3198,6 +3204,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2563,6 +2563,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2939,6 +2939,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2473,6 +2473,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -1860,6 +1860,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3198,6 +3204,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2563,6 +2563,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2569,6 +2569,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2945,6 +2945,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -1866,6 +1866,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3210,6 +3216,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2569,6 +2569,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2945,6 +2945,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -1866,6 +1866,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3201,6 +3207,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2569,6 +2569,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2945,6 +2945,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2479,6 +2479,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -1866,6 +1866,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3201,6 +3207,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2481,6 +2481,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2947,6 +2947,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2571,6 +2571,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -1874,6 +1874,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3203,6 +3209,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2481,6 +2481,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2518,6 +2518,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2518,6 +2518,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2984,6 +2984,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -1905,6 +1905,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3252,6 +3258,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2608,6 +2608,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2518,6 +2518,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2518,6 +2518,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2984,6 +2984,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -1905,6 +1905,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3252,6 +3258,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2608,6 +2608,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2614,6 +2614,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2990,6 +2990,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -1911,6 +1911,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3258,6 +3264,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2614,6 +2614,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2990,6 +2990,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -1911,6 +1911,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3258,6 +3264,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2524,6 +2524,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2614,6 +2614,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2990,6 +2990,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -1911,6 +1911,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3258,6 +3264,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2536,6 +2536,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -1923,6 +1923,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3270,6 +3276,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2626,6 +2626,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2536,6 +2536,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -3002,6 +3002,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2962,6 +2962,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2586,6 +2586,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2496,6 +2496,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2496,6 +2496,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -1931,6 +1931,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3230,6 +3236,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -3113,6 +3113,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -2737,6 +2737,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -2082,6 +2082,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3381,6 +3387,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2488,6 +2488,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2954,6 +2954,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -1923,6 +1923,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3222,6 +3228,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2578,6 +2578,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2488,6 +2488,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2488,6 +2488,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2954,6 +2954,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -1923,6 +1923,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3222,6 +3228,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2578,6 +2578,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2488,6 +2488,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2076,6 +2076,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3375,6 +3381,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -3107,6 +3107,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2731,6 +2731,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2076,6 +2076,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3375,6 +3381,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -3107,6 +3107,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2731,6 +2731,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2076,6 +2076,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3375,6 +3381,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -3107,6 +3107,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2731,6 +2731,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2641,6 +2641,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2076,6 +2076,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3375,6 +3381,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -3107,6 +3107,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2731,6 +2731,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -3113,6 +3113,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -2737,6 +2737,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -2082,6 +2082,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3381,6 +3387,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -3113,6 +3113,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -2737,6 +2737,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -2082,6 +2082,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3381,6 +3387,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -2647,6 +2647,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -3116,6 +3116,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -2740,6 +2740,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -2085,6 +2085,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3384,6 +3390,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -3116,6 +3116,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -2740,6 +2740,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -2085,6 +2085,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3384,6 +3390,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -3116,6 +3116,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -2740,6 +2740,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -2085,6 +2085,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3384,6 +3390,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -3116,6 +3116,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -2740,6 +2740,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -2085,6 +2085,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3384,6 +3390,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -3116,6 +3116,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -2650,6 +2650,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -2740,6 +2740,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -2085,6 +2085,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>enterprise_reminder_rule.from_date</datatype>
             </ignore>
             <ignore>
@@ -3384,6 +3390,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/commerce-to-commerce/settings.xml.dist
+++ b/etc/commerce-to-commerce/settings.xml.dist
@@ -965,6 +965,9 @@
         <ignore>
             <path>web/cookie/*</path>
         </ignore>
+        <ignore>
+            <path>general/locale/timezone</path>
+        </ignore>
         <rename>
             <path>api/config/charset</path>
             <to>webapi/soap/charset</to>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2190,6 +2190,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2280,6 +2280,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2190,6 +2190,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2682,6 +2682,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -1406,6 +1406,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3676,6 +3682,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2289,6 +2289,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2709,6 +2709,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2199,6 +2199,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2199,6 +2199,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2289,6 +2289,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2709,6 +2709,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2199,6 +2199,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -1406,6 +1406,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3673,6 +3679,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2199,6 +2199,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2618,6 +2618,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3480,6 +3486,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2618,6 +2618,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3480,6 +3486,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2618,6 +2618,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3480,6 +3486,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2611,6 +2611,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2111,6 +2111,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -1354,6 +1354,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3455,6 +3461,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2201,6 +2201,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2111,6 +2111,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2608,6 +2608,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2611,6 +2611,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2611,6 +2611,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2611,6 +2611,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2611,6 +2611,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -1357,6 +1357,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3458,6 +3464,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2204,6 +2204,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2114,6 +2114,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -1371,6 +1371,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3484,6 +3490,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2631,6 +2631,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2224,6 +2224,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -1371,6 +1371,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3484,6 +3490,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2631,6 +2631,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2224,6 +2224,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -1371,6 +1371,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3484,6 +3490,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2631,6 +2631,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2224,6 +2224,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -1371,6 +1371,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3484,6 +3490,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2631,6 +2631,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2224,6 +2224,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -1371,6 +1371,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3484,6 +3490,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2134,6 +2134,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2631,6 +2631,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2224,6 +2224,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3496,6 +3502,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2236,6 +2236,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2643,6 +2643,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3496,6 +3502,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2236,6 +2236,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2643,6 +2643,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -2194,6 +2194,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3454,6 +3460,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -2104,6 +2104,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -2601,6 +2601,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -2104,6 +2104,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3496,6 +3502,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2236,6 +2236,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2643,6 +2643,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2146,6 +2146,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -2194,6 +2194,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -1383,6 +1383,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3454,6 +3460,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -2104,6 +2104,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -2601,6 +2601,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -2104,6 +2104,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -1386,6 +1386,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -1386,6 +1386,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -1386,6 +1386,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -1386,6 +1386,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -2604,6 +2604,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -1386,6 +1386,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -3457,6 +3463,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -2197,6 +2197,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>sequence_catalog_category</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -2107,6 +2107,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/settings.xml.dist
+++ b/etc/opensource-to-commerce/settings.xml.dist
@@ -917,6 +917,9 @@
         <ignore>
             <path>web/cookie/*</path>
         </ignore>
+        <ignore>
+            <path>general/locale/timezone</path>
+        </ignore>
         <rename>
             <path>api/config/charset</path>
             <to>webapi/soap/charset</to>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1258,6 +1258,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2355,6 +2361,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -2108,6 +2108,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1577,6 +1577,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1577,6 +1577,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1664,6 +1664,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1589,6 +1589,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1270,6 +1270,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2376,6 +2382,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -2126,6 +2126,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1589,6 +1589,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1676,6 +1676,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1589,6 +1589,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -2126,6 +2126,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1589,6 +1589,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1270,6 +1270,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2373,6 +2379,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1676,6 +1676,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -2047,6 +2047,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2225,6 +2231,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -2047,6 +2047,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2225,6 +2231,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -2047,6 +2047,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2225,6 +2231,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2203,6 +2209,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -2040,6 +2040,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -2037,6 +2037,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1636,6 +1636,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1230,6 +1230,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2200,6 +2206,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1549,6 +1549,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1549,6 +1549,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2209,6 +2215,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -2046,6 +2046,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2209,6 +2215,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -2046,6 +2046,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2209,6 +2215,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -2046,6 +2046,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1233,6 +1233,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2209,6 +2215,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1639,6 +1639,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -2046,6 +2046,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1552,6 +1552,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1247,6 +1247,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2229,6 +2235,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1653,6 +1653,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1247,6 +1247,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2229,6 +2235,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1653,6 +1653,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1247,6 +1247,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2229,6 +2235,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1653,6 +1653,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1247,6 +1247,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2229,6 +2235,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1653,6 +1653,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1247,6 +1247,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2229,6 +2235,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1653,6 +1653,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1566,6 +1566,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -2060,6 +2060,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1665,6 +1665,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1259,6 +1259,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2241,6 +2247,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1578,6 +1578,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -2072,6 +2072,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1578,6 +1578,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1665,6 +1665,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1259,6 +1259,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2241,6 +2247,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1578,6 +1578,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -2072,6 +2072,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1578,6 +1578,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1692,6 +1692,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -2099,6 +2099,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1259,6 +1259,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2268,6 +2274,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1605,6 +1605,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1605,6 +1605,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -1265,6 +1265,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2271,6 +2277,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -1695,6 +1695,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -1608,6 +1608,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -2102,6 +2102,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -1268,6 +1268,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2274,6 +2280,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -1698,6 +1698,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -2105,6 +2105,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -1268,6 +1268,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2274,6 +2280,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -1698,6 +1698,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -2105,6 +2105,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -1268,6 +1268,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2274,6 +2280,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -1698,6 +1698,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -2105,6 +2105,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -1268,6 +1268,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2274,6 +2280,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -1698,6 +1698,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -2105,6 +2105,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -1268,6 +1268,12 @@
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
             </ignore>
             <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
+            </ignore>
+            <ignore>
                 <datatype>oauth_token.callback_url</datatype>
             </ignore>
             <ignore>
@@ -2274,6 +2280,12 @@
             </ignore>
             <ignore>
                 <datatype>oauth_consumer.rejected_callback_url</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_category_entity_text.value</datatype>
+            </ignore>
+            <ignore>
+                <datatype>catalog_product_entity_text.value</datatype>
             </ignore>
             <ignore>
                 <datatype>oauth_token.callback_url</datatype>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -1698,6 +1698,12 @@
                 <document>vertex_sales_order_item_vertex_tax_code</document>
             </ignore>
             <ignore>
+                <document>vertex_commodity_code_order_item</document>
+            </ignore>
+            <ignore>
+                <document>vertex_commodity_code_product</document>
+            </ignore>
+            <ignore>
                 <document>eav_attribute_option_swatch</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -2105,6 +2105,9 @@
                 <field>catalog_product_entity_media_gallery_value.record_id</field>
             </ignore>
             <ignore>
+                <field>catalog_compare_item.list_id</field>
+            </ignore>
+            <ignore>
                 <field>admin_user.interface_locale</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>email_sms_order_queue</document>
+            </ignore>
+            <ignore>
                 <document>catalog_compare_list</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -1611,6 +1611,9 @@
                 <document>email_failed_auth</document>
             </ignore>
             <ignore>
+                <document>catalog_compare_list</document>
+            </ignore>
+            <ignore>
                 <document>temando_checkout_address</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/settings.xml.dist
+++ b/etc/opensource-to-opensource/settings.xml.dist
@@ -917,6 +917,9 @@
         <ignore>
             <path>web/cookie/*</path>
         </ignore>
+        <ignore>
+            <path>general/locale/timezone</path>
+        </ignore>
         <rename>
             <path>api/config/charset</path>
             <to>webapi/soap/charset</to>

--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -496,7 +496,43 @@ class Data implements StageInterface, RollbackInterface
         );
         foreach ($customEntityAttributes as $record) {
             if (!isset($this->mapAttributeGroupIdsSourceDest[$record['attribute_group_id']])) {
-                continue;
+                // create the group id
+                $this->migrateAttributeGroups([$record['attribute_group_id']]);
+
+                /*$productAttributeSetIds = array_keys($this->modelData->getAttributeSets(
+                    $record['entity_type_id'],
+                    ModelData::ATTRIBUTE_SETS_NONE_DEFAULT
+                ));*/
+
+                $attributeGroupsDestination = $this->helper->getDestinationRecords(
+                    'eav_attribute_group',
+                    ['attribute_group_id']
+                );
+                $attributeGroupsSource = $this->helper->getSourceRecords(
+                    'eav_attribute_group',
+                    ['attribute_group_id']
+                );
+
+                foreach ($attributeGroupsSource as $idSource => $recordSource) {
+                    $sourceAttributeGroupName = $recordSource['attribute_group_name'];
+                    /*if (in_array($recordSource['attribute_set_id'], $productAttributeSetIds)) {
+                        $sourceAttributeGroupName = str_replace(
+                            array_keys($this->mapProductAttributeGroupNamesSourceDest),
+                            $this->mapProductAttributeGroupNamesSourceDest,
+                            $recordSource['attribute_group_name']
+                        );
+                    }*/
+                    $sourceKey = $recordSource['attribute_set_id'] . ' ' . $sourceAttributeGroupName;
+                    foreach ($attributeGroupsDestination as $idDestination => $recordDestination) {
+                        $destinationKey = $recordDestination['attribute_set_id']
+                            . ' '
+                            . $recordDestination['attribute_group_name'];
+                        if ($sourceKey == $destinationKey) {
+                            $this->mapAttributeGroupIdsSourceDest[$recordSource['attribute_group_id']] =
+                                $recordDestination['attribute_group_id'];
+                        }
+                    }
+                }
             }
             $record['sort_order'] = $this->getCustomAttributeSortOrder($record);
             $record['attribute_group_id'] = $this->mapAttributeGroupIdsSourceDest[$record['attribute_group_id']];

--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -568,6 +568,9 @@ class Data implements StageInterface, RollbackInterface
 
             $recordsToSave = $destinationDocument->getRecords();
             foreach ($destinationRecords as $record) {
+                if (!isset($this->mapAttributeIdsDestOldNew[$record['attribute_id']])) {
+                    continue;
+                }
                 $record['attribute_id'] = $this->mapAttributeIdsDestOldNew[$record['attribute_id']];
                 $destinationRecord = $this->factory->create([
                     'document' => $destinationDocument,


### PR DESCRIPTION
## Scope
### Tasks
- [MC-40765](https://jira.corp.magento.com/browse/MC-40765) DMT 2.4.2 Publication

### Bugs
- [MC-38314](https://jira.corp.magento.com/browse/MC-38314) [Github] [PR] Add support for non-default attribute set groups
- [MC-39089](https://jira.corp.magento.com/browse/MC-39089)  Data Migration Tool: Time difference
- [MC-40766](https://jira.corp.magento.com/browse/MC-40766) Catalog module have new table catalog_compare_list and causes error during migration
- [MC-40767](https://jira.corp.magento.com/browse/MC-40767) New table email_sms_order_queue prevents migration
- [MC-40768](https://jira.corp.magento.com/browse/MC-40768) Vertex module cause migration to stop
- [MC-40769](https://jira.corp.magento.com/browse/MC-40769) Field catalog_compare_item.list_id causes error during migration
- [MC-40770](https://jira.corp.magento.com/browse/MC-40770) Mismatch of data types warning for EAV tables
