### PR TITLE
fix(delta): fix the wrong table prefix

### DIFF
--- a/src/Migration/Step/UrlRewrite/Version191to2000Delta.php
+++ b/src/Migration/Step/UrlRewrite/Version191to2000Delta.php
@@ -131,7 +131,7 @@ class Version191to2000Delta extends AbstractDelta
         $select = $this->cmsPageRewrites->getSelect();
         $urlRewrites = $this->source->getAdapter()->loadDataFromSelect($select);
         $this->destination->saveRecords(
-            $this->source->addDocumentPrefix(Version191to2000::DESTINATION),
+            $this->destination->addDocumentPrefix(Version191to2000::DESTINATION),
             $urlRewrites,
             true
         );


### PR DESCRIPTION
### Description
<!--- Provide a description of the changes proposed in the pull request -->

during the migration of delta data, if the source table has a table prefix and the destination table doesn't have a table prefix or other prefixes, the migration process fails and tells that the destination table could not be found.


### Fixed Issues (if relevant)
1. magento/data-migration-tool#<issue_number>: Issue title
2. ...

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. In the config file `app/code/Vendor/Migration/etc/opensource-to-opensource/1.9.2.0/config.xml`, in the section `options`, define different table prefixes like:
```
        <source_prefix>magento_</source_prefix>
        <dest_prefix />
```

2. run the CLI command `bin/magento migrate:delta -a app/code/Vendor/Migration/etc/opensource-to-opensource/1.9.2.0/config.xml`

### Contribution checklist
 - [x] Pull request has a meaningful description of its purpose
 - [x] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 