### PR TITLE
add update on duplicate for attribute groups 

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -392,7 +392,7 @@ class Data implements StageInterface, RollbackInterface
             $recordTransformer->transform($sourceRecord, $destinationRecord);
             $recordsToSave->addRecord($destinationRecord);
         }
-        $this->saveRecords($destinationDocument, $recordsToSave);
+        $this->saveRecords($destinationDocument, $recordsToSave, true);
     }
 
     /**
@@ -587,14 +587,15 @@ class Data implements StageInterface, RollbackInterface
      *
      * @param Document|string $document
      * @param Record\Collection|array $recordsToSave
+     * @param bool $updateOnDuplicate
      * @return void
      */
-    private function saveRecords($document, $recordsToSave)
+    private function saveRecords($document, $recordsToSave, $updateOnDuplicate = false)
     {
         if (is_object($document)) {
             $document = $document->getName();
         }
-        $this->destination->saveRecords($document, $recordsToSave);
+        $this->destination->saveRecords($document, $recordsToSave, $updateOnDuplicate);
     }
 
     /**


### PR DESCRIPTION
Fixes #869

Code provided by @jriboux-advisa https://github.com/magento/data-migration-tool/issues/869#issuecomment-801516008

### Description
<!--- Provide a description of the changes proposed in the pull request -->

### Fixed Issues (if relevant)
1. magento/data-migration-tool#869: SQLSTATE[23000]: Integrity constraint violation: 1062 Duplicate entry '11-general' for key 'EAV_ATTRIBUTE_GROUP_ATTRIBUTE_SET_ID_ATTRIBUTE_GROUP_CODE'

### Manual testing scenarios
<!--- Provide a set of unambiguous steps to test the proposed code change -->
1. Have custom order attribute in M1
2. Run migration

### Contribution checklist
 - [X] Pull request has a meaningful description of its purpose
 - [X] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 