### PR TITLE
Map custom attribute groups

### DIFF
--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -392,7 +392,7 @@ class Data implements StageInterface, RollbackInterface
             $sourceRecord = $this->factory->create(['document' => $sourceDocument, 'data' => $recordData]);
             $destinationRecord = $this->factory->create(['document' => $destinationDocument]);
             $recordTransformer->transform($sourceRecord, $destinationRecord);
-            $recordsToSave->addRecord($destinationRecord);
+            
 
             $sourceAttributeGroupName = $recordData['attribute_group_name'];
             $destAttributeGroupName = $destinationRecord->getValue('attribute_group_name');
@@ -400,7 +400,10 @@ class Data implements StageInterface, RollbackInterface
                 && !in_array($sourceAttributeGroupName, $attributeNameMapping)
                 && $sourceAttributeGroupName != $destAttributeGroupName ) {
                 $attributeNameMapping[$sourceAttributeGroupName] = $destAttributeGroupName;
+                $sortOrder = $destinationRecord->getValue('sort_order') + 200;
+                $destinationRecord->setValue('sort_order', $sortOrder);
             }
+            $recordsToSave->addRecord($destinationRecord);
         }
         $this->saveRecords($destinationDocument, $recordsToSave);
         $this->mapProductAttributeGroupNamesSourceDest = $attributeNameMapping;
@@ -645,6 +648,9 @@ class Data implements StageInterface, RollbackInterface
         );
         foreach ($this->initialData->getAttributeSets(ModelData::TYPE_DEST) as $attributeSetId => $record) {
             $entityTypeId = $this->mapEntityTypeIdsDestOldNew[$record['entity_type_id']];
+            if (!isset($this->newAttributeSets[$entityTypeId . '-' . $record['attribute_set_name']])) {
+                continue;
+            }
             $newAttributeSet = $this->newAttributeSets[$entityTypeId . '-' . $record['attribute_set_name']];
             $this->mapAttributeSetIdsDestOldNew[$attributeSetId] = $newAttributeSet['attribute_set_id'];
             $this->defaultAttributeSetIds[$newAttributeSet['entity_type_id']] = $newAttributeSet['attribute_set_id'];

--- a/src/Migration/Step/Eav/Data.php
+++ b/src/Migration/Step/Eav/Data.php
@@ -385,14 +385,25 @@ class Data implements StageInterface, RollbackInterface
         );
         $recordsToSave = $destinationDocument->getRecords();
         $recordTransformer = $this->helper->getRecordTransformer($sourceDocument, $destinationDocument);
+        $attributeNameMapping = $this->mapProductAttributeGroupNamesSourceDest;
+        $productAttributeSetIds = array_keys($this->modelData->getProductAttributeSets());
         foreach ($sourceRecords as $recordData) {
             $recordData['attribute_group_id'] = null;
             $sourceRecord = $this->factory->create(['document' => $sourceDocument, 'data' => $recordData]);
             $destinationRecord = $this->factory->create(['document' => $destinationDocument]);
             $recordTransformer->transform($sourceRecord, $destinationRecord);
             $recordsToSave->addRecord($destinationRecord);
+
+            $sourceAttributeGroupName = $recordData['attribute_group_name'];
+            $destAttributeGroupName = $destinationRecord->getValue('attribute_group_name');
+            if (in_array($recordData['attribute_set_id'], $productAttributeSetIds)
+                && !in_array($sourceAttributeGroupName, $attributeNameMapping)
+                && $sourceAttributeGroupName != $destAttributeGroupName ) {
+                $attributeNameMapping[$sourceAttributeGroupName] = $destAttributeGroupName;
+            }
         }
         $this->saveRecords($destinationDocument, $recordsToSave);
+        $this->mapProductAttributeGroupNamesSourceDest = $attributeNameMapping;
     }
 
     /**


### PR DESCRIPTION
### Description
This PR adds the custom attribute groups to `mapProductA
[FFP2-Vorlage.pdf](https://github.com/magento/data-migration-tool/files/8079329/FFP2-Vorlage.pdf)
ttributeGroupNamesSourceDest` Mapping array so that the attributes in the group get also added to the correct group on the destination system.
Furthermore the sorting is updated so that the custom attributes are sorted after the default attributes. Therefore 200 is added to the sorting value. I used this value because it is also used in `getCustomAttributeSortOrder` for attributes.

### Fixed Issues (if relevant)
1. magento/data-migration-tool#888: Custom product attribute groups empty when migrating from 1.9.2.2 to 2.4.3

### Manual testing scenarios
1. Starting with Magento 1.9.2.2 having an attribute set with custom attribute groups with attributes assigned
2. Migrate data to Magento 2.4.3
3. The custom attribute group have now attributes assigned again
