### PR TITLE
Data Migration Tool Release 2.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,26 @@
+2.4.4
+=============
+* Added support for versions:
+
+    * Magento Open Source: 2.4.4
+    * Magento Commerce: 2.4.4
+
+* Fixed bugs:
+
+    * New monolog version caused composer dependency conflict
+    * Customer login is not working after Migration from Magento 1.x
+
+2.4.3
+=============
+* Added support for versions:
+
+    * Magento Open Source: 2.4.3
+    * Magento Commerce: 2.4.3
+
+* Fixed bugs:
+
+    * Delta fix the wrong table prefix
+
 2.4.2
 =============
 * Added support for versions:

--- a/README.md
+++ b/README.md
@@ -58,16 +58,17 @@ This section discusses how to install the Magento Data Migration Tool. You can i
 ### Install the tool from GitHub
 To install the migration tool from GitHub, use the following steps:
 
-1.  Log in to your Magento 2 server as a user with privileges to write to the Magento 2 file system or <a href="http://devdocs.magento.com/guides/v2.4/install-gde/install/prepare-install.html#install-update-depend-apache">switch to the web server user</a>.
-2.  Go to Magento 2 root directory.
-3.  Enter the following commands:
+1. Log in to your Magento 2 server as a user with privileges to write to the Magento 2 file system or <a href="http://devdocs.magento.com/guides/v2.4/install-gde/install/prepare-install.html#install-update-depend-apache">switch to the web server user</a>.
+2. Go to Magento 2 root directory.
+3. Enter the following commands:
 
         composer config repositories.data-migration-tool git https://github.com/magento/data-migration-tool
         composer require magento/data-migration-tool:<version>
+        bin/magento module:enable Magento_DataMigrationTool
 
-    where `<version>` is release version (e.g. 2.4.0)
+    where `<version>` is release version (e.g. 2.4.4)
 
-3.  Wait while dependencies are updated.
+5. Wait while dependencies are updated and the tool is enabled.
 
 ### Install the tool from repo.magento.com
 To install the Data Migration Tool, you must update `composer.json` in the Magento root installation directory to provide the location of the migration tool package.
@@ -82,15 +83,15 @@ To install the migration tool, you must:
 
 To update `composer.json`:
 
-1.  Log in to your Magento server as the <a href="http://devdocs.magento.com/guides/v2.4/install-gde/install/prepare-install.html#install-update-depend-apacheweb">web server user</a> or as a user with `root` privileges.
+1. Log in to your Magento server as the <a href="http://devdocs.magento.com/guides/v2.4/install-gde/install/prepare-install.html#install-update-depend-apacheweb">web server user</a> or as a user with `root` privileges.
 
-2.  Change to your Magento installation directory.
+2. Change to your Magento installation directory.
 
-3.  Enter the following command to reference Magento packages in `composer.json`:
+3. Enter the following command to reference Magento packages in `composer.json`:
 
         composer config repositories.magento composer https://repo.magento.com
 
-4.  Enter the following command to require the current version of the package:
+4. Enter the following command to require the current version of the package:
 
         composer require magento/data-migration-tool:<version>
 
@@ -98,13 +99,16 @@ To update `composer.json`:
 
     Exact version example:
 
-        composer require magento/data-migration-tool:2.4.0
+        composer require magento/data-migration-tool:2.4.4
 
     Next significant release example:
 
         composer require magento/data-migration-tool:~2.4
 
-5.  Wait while dependencies are installed.
+5. Wait while dependencies are installed.
+6. Enter the following command to enable the tool
+
+        bin/magento module:enable Magento_DataMigrationTool
 
 ## More details
 See the <a href="http://devdocs.magento.com/guides/v2.4/migration/bk-migration-guide.html">Migration Guide</a> for the detailed help with your data migration process.

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "require": {
         "symfony/console": "~4.4.0",
         "magento/framework": "*",
-        "monolog/monolog": "^1.17"
+        "monolog/monolog": "^2.3"
     },
     "require-dev": {
         "phpunit/phpunit": "^9"

--- a/composer.json
+++ b/composer.json
@@ -1,14 +1,14 @@
 {
     "name": "magento/data-migration-tool",
     "description": "Migration Tool",
-    "version": "2.4.3",
+    "version": "2.4.4",
     "require": {
         "symfony/console": "~4.4.0",
         "magento/framework": "*",
         "monolog/monolog": "^2.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9"
+        "phpunit/phpunit": "~9.5.0"
     },
     "autoload": {
         "psr-4": {"Migration\\": "src/Migration"},

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -2884,6 +2884,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -2884,6 +2884,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -2872,6 +2872,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -2860,6 +2860,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -2860,6 +2860,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -2782,6 +2782,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -2782,6 +2782,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -2782,6 +2782,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -2775,6 +2775,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -2775,6 +2775,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -2775,6 +2775,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -2781,6 +2781,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -2781,6 +2781,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -2781,6 +2781,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -2783,6 +2783,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -2820,6 +2820,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -2820,6 +2820,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -2826,6 +2826,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -2826,6 +2826,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -2826,6 +2826,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -2838,6 +2838,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -2798,6 +2798,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -2949,6 +2949,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -2790,6 +2790,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -2790,6 +2790,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -2943,6 +2943,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -2943,6 +2943,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -2943,6 +2943,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -2943,6 +2943,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -2949,6 +2949,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -2949,6 +2949,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -2952,6 +2952,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -2952,6 +2952,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -2952,6 +2952,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -2952,6 +2952,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -2952,6 +2952,9 @@
             <ignore>
                 <document>email_coupon_attribute</document>
             </ignore>
+            <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
         </document_rules>
         <field_rules>
             <transform>

--- a/etc/commerce-to-commerce/map-customer.xml.dist
+++ b/etc/commerce-to-commerce/map-customer.xml.dist
@@ -101,6 +101,9 @@
                 <field>customer_entity.gender</field>
             </ignore>
             <ignore>
+                <field>customer_entity.session_cutoff</field>
+            </ignore>
+            <ignore>
                 <field>customer_address_entity.city</field>
             </ignore>
             <ignore>

--- a/etc/commerce-to-commerce/map-log.xml.dist
+++ b/etc/commerce-to-commerce/map-log.xml.dist
@@ -16,14 +16,15 @@
         </document_rules>
         <field_rules>
             <ignore>
-                <field>log_visitor.first_visit_at</field>
-            </ignore>
-            <ignore>
                 <field>log_visitor.last_url_id</field>
             </ignore>
             <ignore>
                 <field>log_visitor.store_id</field>
             </ignore>
+            <move>
+                <field>log_visitor.first_visit_at</field>
+                <to>customer_visitor.created_at</to>
+            </move>
         </field_rules>
     </source>
     <destination>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -2487,6 +2487,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -2502,6 +2502,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -2502,6 +2502,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -2414,6 +2414,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -2417,6 +2417,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -2437,6 +2437,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -2449,6 +2449,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -2449,6 +2449,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -2407,6 +2407,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -2449,6 +2449,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -2407,6 +2407,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -2410,6 +2410,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/map-customer.xml.dist
+++ b/etc/opensource-to-commerce/map-customer.xml.dist
@@ -101,6 +101,9 @@
                 <field>customer_entity.gender</field>
             </ignore>
             <ignore>
+                <field>customer_entity.session_cutoff</field>
+            </ignore>
+            <ignore>
                 <field>customer_address_entity.city</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/map-log.xml.dist
+++ b/etc/opensource-to-commerce/map-log.xml.dist
@@ -16,9 +16,6 @@
         </document_rules>
         <field_rules>
             <ignore>
-                <field>log_visitor.first_visit_at</field>
-            </ignore>
-            <ignore>
                 <field>log_visitor.last_url_id</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-commerce/map-log.xml.dist
+++ b/etc/opensource-to-commerce/map-log.xml.dist
@@ -24,6 +24,10 @@
             <ignore>
                 <field>log_visitor.store_id</field>
             </ignore>
+            <move>
+                <field>log_visitor.first_visit_at</field>
+                <to>customer_visitor.created_at</to>
+            </move>
         </field_rules>
     </source>
     <destination>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -1955,6 +1955,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -1955,6 +1955,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -1955,6 +1955,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -1882,6 +1882,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -1882,6 +1882,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -1882,6 +1882,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -1882,6 +1882,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -1879,6 +1879,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -1888,6 +1888,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -1888,6 +1888,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -1888,6 +1888,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -1888,6 +1888,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -1902,6 +1902,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -1902,6 +1902,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -1902,6 +1902,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -1902,6 +1902,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -1902,6 +1902,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -1914,6 +1914,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -1914,6 +1914,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -1941,6 +1941,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -1944,6 +1944,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -1947,6 +1947,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -1947,6 +1947,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -1947,6 +1947,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -1947,6 +1947,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -1947,6 +1947,9 @@
                 <document>email_coupon_attribute</document>
             </ignore>
             <ignore>
+                <document>jwt_auth_revoked</document>
+            </ignore>
+            <ignore>
                 <document>magento_acknowledged_bulk</document>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/map-customer.xml.dist
+++ b/etc/opensource-to-opensource/map-customer.xml.dist
@@ -101,6 +101,9 @@
                 <field>customer_entity.gender</field>
             </ignore>
             <ignore>
+                <field>customer_entity.session_cutoff</field>
+            </ignore>
+            <ignore>
                 <field>customer_address_entity.city</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/map-log.xml.dist
+++ b/etc/opensource-to-opensource/map-log.xml.dist
@@ -16,9 +16,6 @@
         </document_rules>
         <field_rules>
             <ignore>
-                <field>log_visitor.first_visit_at</field>
-            </ignore>
-            <ignore>
                 <field>log_visitor.last_url_id</field>
             </ignore>
             <ignore>

--- a/etc/opensource-to-opensource/map-log.xml.dist
+++ b/etc/opensource-to-opensource/map-log.xml.dist
@@ -24,6 +24,10 @@
             <ignore>
                 <field>log_visitor.store_id</field>
             </ignore>
+            <move>
+                <field>log_visitor.first_visit_at</field>
+                <to>customer_visitor.created_at</to>
+            </move>
         </field_rules>
     </source>
     <destination>

--- a/src/Migration/Logger/ConsoleHandler.php
+++ b/src/Migration/Logger/ConsoleHandler.php
@@ -5,10 +5,16 @@
  */
 namespace Migration\Logger;
 
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\FormattableHandlerInterface;
+use Monolog\Handler\HandlerInterface;
+use Monolog\Handler\AbstractHandler;
+use Psr\Log\LogLevel;
+
 /**
  * Processing logger handler creation for migration application
  */
-class ConsoleHandler extends \Monolog\Handler\AbstractHandler implements \Monolog\Handler\HandlerInterface
+class ConsoleHandler extends AbstractHandler implements HandlerInterface, FormattableHandlerInterface
 {
     const COLOR_RESET   = '0';
     const COLOR_BLACK   = '0;30';
@@ -19,6 +25,11 @@ class ConsoleHandler extends \Monolog\Handler\AbstractHandler implements \Monolo
     const COLOR_MAGENTA = '0;35';
     const COLOR_CYAN    = '0;36';
     const COLOR_WHITE   = '0;37';
+
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
 
     /**
      * Paint the message to specified color
@@ -42,19 +53,43 @@ class ConsoleHandler extends \Monolog\Handler\AbstractHandler implements \Monolo
         }
         $record['formatted'] = $this->getFormatter()->format($record);
         switch ($record['level']) {
-            case Logger::ERROR:
-            case Logger::CRITICAL:
+            case LogLevel::ERROR:
+            case LogLevel::CRITICAL:
                 echo PHP_EOL . $this->colorize($record['formatted'], self::COLOR_RED);
                 break;
-            case Logger::WARNING:
+            case LogLevel::WARNING:
                 echo PHP_EOL . $this->colorize($record['formatted'], self::COLOR_YELLOW);
                 break;
-            case Logger::NOTICE:
+            case LogLevel::NOTICE:
                 echo PHP_EOL . $this->colorize($record['formatted'], self::COLOR_BLUE);
                 break;
             default:
                 echo PHP_EOL . $record['formatted'];
         }
         return false === $this->bubble;
+    }
+
+    /**
+     * Sets the formatter.
+     *
+     * @param FormatterInterface $formatter
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+        return $this;
+    }
+
+    /**
+     * Gets the formatter.
+     *
+     * @return FormatterInterface
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if (!$this->formatter) {
+            throw new \LogicException('No formatter has been set and this handler does not have a default formatter');
+        }
+        return $this->formatter;
     }
 }

--- a/src/Migration/Logger/ConsoleHandler.php
+++ b/src/Migration/Logger/ConsoleHandler.php
@@ -35,7 +35,7 @@ class ConsoleHandler extends \Monolog\Handler\AbstractHandler implements \Monolo
     /**
      * @inheritdoc
      */
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/src/Migration/Logger/FileHandler.php
+++ b/src/Migration/Logger/FileHandler.php
@@ -8,6 +8,8 @@ namespace Migration\Logger;
 use Magento\Framework\Filesystem\Driver\File;
 use Migration\Config;
 use Magento\Framework\App\Filesystem\DirectoryList;
+use Monolog\Formatter\FormatterInterface;
+use Monolog\Handler\HandlerInterface;
 
 /**
  * Processing logger handler creation for migration application
@@ -30,6 +32,11 @@ class FileHandler extends \Monolog\Handler\AbstractHandler implements \Monolog\H
      * @var Config
      */
     protected $config;
+
+    /**
+     * @var FormatterInterface
+     */
+    private $formatter;
 
     /**
      * @param File $file
@@ -84,5 +91,29 @@ class FileHandler extends \Monolog\Handler\AbstractHandler implements \Monolog\H
                 . basename($logFile);
         }
         return $logFile;
+    }
+
+    /**
+     * Sets the formatter.
+     *
+     * @param FormatterInterface $formatter
+     */
+    public function setFormatter(FormatterInterface $formatter): HandlerInterface
+    {
+        $this->formatter = $formatter;
+        return $this;
+    }
+
+    /**
+     * Gets the formatter.
+     *
+     * @return FormatterInterface
+     */
+    public function getFormatter(): FormatterInterface
+    {
+        if (!$this->formatter) {
+            throw new \LogicException('No formatter has been set and this handler does not have a default formatter');
+        }
+        return $this->formatter;
     }
 }

--- a/src/Migration/Logger/FileHandler.php
+++ b/src/Migration/Logger/FileHandler.php
@@ -47,7 +47,7 @@ class FileHandler extends \Monolog\Handler\AbstractHandler implements \Monolog\H
     /**
      * @inheritdoc
      */
-    public function handle(array $record)
+    public function handle(array $record): bool
     {
         if (!$this->isHandling($record)) {
             return false;

--- a/src/Migration/Logger/Logger.php
+++ b/src/Migration/Logger/Logger.php
@@ -31,7 +31,7 @@ class Logger extends \Monolog\Logger
     /**
      * @inheritdoc
      */
-    public function addRecord($level, $message, array $context = [])
+    public function addRecord(int $level, string $message, array $context = []): bool
     {
         parent::addRecord($level, $message, $context);
         self::$messages[$level][] = $message;

--- a/src/Migration/Logger/Logger.php
+++ b/src/Migration/Logger/Logger.php
@@ -33,8 +33,9 @@ class Logger extends \Monolog\Logger
      */
     public function addRecord(int $level, string $message, array $context = []): bool
     {
-        parent::addRecord($level, $message, $context);
+        $processed = parent::addRecord($level, $message, $context);
         self::$messages[$level][] = $message;
+        return $processed;
     }
 
     /**

--- a/src/Migration/Logger/Manager.php
+++ b/src/Migration/Logger/Manager.php
@@ -6,6 +6,8 @@
 
 namespace Migration\Logger;
 
+use Psr\Log\LogLevel;
+
 /**
  * Processing logger handler creation for migration application
  */
@@ -47,9 +49,9 @@ class Manager
      * @var array
      */
     protected $logLevels = [
-        self::LOG_LEVEL_ERROR => Logger::ERROR,
-        self::LOG_LEVEL_INFO => Logger::INFO,
-        self::LOG_LEVEL_DEBUG => Logger::DEBUG
+        self::LOG_LEVEL_ERROR => LogLevel::ERROR,
+        self::LOG_LEVEL_INFO => LogLevel::INFO,
+        self::LOG_LEVEL_DEBUG => LogLevel::DEBUG
     ];
 
     /**

--- a/src/Migration/Logger/MessageFormatter.php
+++ b/src/Migration/Logger/MessageFormatter.php
@@ -18,7 +18,7 @@ class MessageFormatter extends \Monolog\Formatter\LineFormatter implements \Mono
     /**
      * @inheritdoc
      */
-    public function format(array $record)
+    public function format(array $record): string
     {
         $this->format = $this->getLevelFormat($record['level_name']);
         return parent::format($record);

--- a/src/Migration/Model/PasswordHashResolver.php
+++ b/src/Migration/Model/PasswordHashResolver.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+namespace Migration\Model;
+
+use Magento\Customer\Model\Customer;
+use Magento\Customer\Model\ResourceModel\Customer as CustomerResourceModel;
+
+/**
+ * Class password hash resolver
+ */
+class PasswordHashResolver
+{
+    /**
+     * @param CustomerResourceModel $customerResourceModel
+     */
+    public function __construct(
+        CustomerResourceModel $customerResourceModel
+    ) {
+        $this->customerResourceModel = $customerResourceModel;
+    }
+
+    /**
+     * Resolve password hash
+     *
+     * @param Customer $customer
+     * @return mixed
+     */
+    public function resolve(Customer $customer)
+    {
+        $select = $this->customerResourceModel->getConnection()->select();
+        $select->from(
+                ['ce' => $this->customerResourceModel->getTable('customer_entity_varchar')],
+                'ce.value'
+            );
+        $select->where('ce.attribute_id = ?', $customer->getAttribute('password_hash')->getId());
+        $select->where('ce.entity_id = ?', $customer->getId());
+        $passwordHash = $select->getAdapter()->fetchOne($select);
+        $passwordHash = $passwordHash ?: $customer->getPasswordHash();
+        return $passwordHash;
+    }
+}

--- a/src/Migration/Model/PasswordVerifier.php
+++ b/src/Migration/Model/PasswordVerifier.php
@@ -14,12 +14,20 @@ class PasswordVerifier
      * Verify password
      *
      * @param string $password
-     * @param string $hash
-     * @return bool
+     * @param string $passwordHash
+     * @return bool|void
      */
-    public function verify($password, $hash)
+    public function verify($password, $passwordHash)
     {
-        return password_verify($password, $hash);
+        $passwordHashExplode = explode(':', $passwordHash);
+        $hash = $passwordHashExplode[0];
+        $salt = $passwordHashExplode[1] ?? '';
+        if ($this->isBcrypt($hash)) {
+            return password_verify($password, $hash);
+        } else if ($this->isSha512($hash)) {
+            return hash('sha512', $salt . $password) === $hash;
+        }
+        return;
     }
 
     /**
@@ -31,6 +39,21 @@ class PasswordVerifier
     public function isBcrypt($hash)
     {
         if (stripos($hash, '$2y$') === 0) {
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Check if hash is sha-512 algorithm
+     *
+     * @param string $hash
+     * @return bool
+     */
+    public function isSha512($hash)
+    {
+        $hash = explode(':', $hash)[0];
+        if (strlen($hash) === 128) {
             return true;
         }
         return false;


### PR DESCRIPTION
## Scope
### Tasks
- [ACP2E-627](https://jira.corp.magento.com/browse/ACP2E-627) DMT 2.4.4 Publication

### Bugs
- [ACP2E-505](https://jira.corp.magento.com/browse/ACP2E-505) [Github] Composer Dependency Conflict with v2.4.3 #880
- [ACP2E-370](https://jira.corp.magento.com/browse/ACP2E-370) [Magento Cloud] Customer login is not working after Migration from Magento 1.x
- [ACP2E-730](https://jira.corp.magento.com/browse/ACP2E-730) Customer module have new table fields which causes error during migration
- [ACP2E-731](https://jira.corp.magento.com/browse/ACP2E-731) JwtUserToken module have new table jwt_auth_revoked and causes error during migration
- [ACP2E-734](https://jira.corp.magento.com/browse/ACP2E-734) readme.md does not contain instructions to enable module of the tool

