### PR TITLE
2.4.6.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "magento/data-migration-tool",
     "description": "Migration Tool",
-    "version": "2.4.6",
+    "version": "2.4.6.1",
     "require": {
         "symfony/console": "^5.4",
         "magento/framework": "*",

--- a/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.0/map.xml.dist
@@ -612,6 +612,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.1/map.xml.dist
@@ -612,6 +612,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.0.2/map.xml.dist
@@ -612,6 +612,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.1.0/map.xml.dist
@@ -612,6 +612,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.11.2.0/map.xml.dist
@@ -612,6 +612,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.0/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.1/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.12.0.2/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.0/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.1/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.0.2/map.xml.dist
@@ -618,6 +618,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.13.1.0/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.0/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.0.1/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.1.0/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.0/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.1/map.xml.dist
@@ -624,6 +624,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.2/map.xml.dist
@@ -630,6 +630,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.3/map.xml.dist
@@ -630,6 +630,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.2.4/map.xml.dist
@@ -630,6 +630,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.0/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.1/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.10/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.2/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.3/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.4/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.6/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.7/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.8/map.xml.dist
@@ -633,6 +633,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.3.9/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.0/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.1/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.2/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.3/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.4/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
+++ b/etc/commerce-to-commerce/1.14.4.5/map.xml.dist
@@ -639,6 +639,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.0.0/map.xml.dist
@@ -486,6 +486,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.1.0/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.6.2.0/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.7.0.2/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.8.1.0/map.xml.dist
@@ -471,6 +471,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.0.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.1.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.2/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.3/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.2.4/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.0/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.1/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.10/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.2/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.3/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.4/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.6/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.7/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.8/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.3.9/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.0/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.1/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.2/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.3/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.4/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-commerce/1.9.4.5/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.1.0/map.xml.dist
@@ -471,6 +471,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.6.2.0/map.xml.dist
@@ -471,6 +471,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.7.0.2/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.8.1.0/map.xml.dist
@@ -471,6 +471,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.0.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.1.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.0/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.1/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.2/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.3/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.2.4/map.xml.dist
@@ -474,6 +474,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.0/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.1/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.10/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.2/map.xml.dist
@@ -477,6 +477,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.3/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.4/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.6/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.7/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.8/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.3.9/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.0/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.1/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.2/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.3/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.4/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
+++ b/etc/opensource-to-opensource/1.9.4.5/map.xml.dist
@@ -483,6 +483,18 @@
             <ignore>
                 <document>core_website</document>
             </ignore>
+            <ignore>
+                <document>directory_country</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_format</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region</document>
+            </ignore>
+            <ignore>
+                <document>directory_country_region_name</document>
+            </ignore>
             <rename>
                 <document>catalogsearch_query</document>
                 <to>search_query</to>

--- a/src/Migration/Logger/FileHandler.php
+++ b/src/Migration/Logger/FileHandler.php
@@ -34,6 +34,11 @@ class FileHandler extends \Monolog\Handler\AbstractHandler implements \Monolog\H
     protected $config;
 
     /**
+     * @var \Magento\Framework\Filesystem
+     */
+    private $filesystem;
+
+    /**
      * @var FormatterInterface
      */
     private $formatter;

--- a/src/Migration/Model/PasswordHashResolver.php
+++ b/src/Migration/Model/PasswordHashResolver.php
@@ -13,6 +13,12 @@ use Magento\Customer\Model\ResourceModel\Customer as CustomerResourceModel;
  */
 class PasswordHashResolver
 {
+
+    /**
+     * @var CustomerResourceModel
+     */
+    protected $customerResourceModel;
+
     /**
      * @param CustomerResourceModel $customerResourceModel
      */

--- a/src/Migration/Step/Customer/Model/SourceRecordsCounter.php
+++ b/src/Migration/Step/Customer/Model/SourceRecordsCounter.php
@@ -20,6 +20,11 @@ class SourceRecordsCounter
     private $source;
 
     /**
+     * @var EntityTypeCode
+     */
+    private $entityTypeCode;
+
+    /**
      * @var AttributesDataToSkip
      */
     private $attributesDataToSkip;

--- a/src/Migration/Step/Eav/Helper.php
+++ b/src/Migration/Step/Eav/Helper.php
@@ -30,6 +30,11 @@ class Helper
      */
     protected $destination;
 
+     /**
+     * @var Source
+     */
+    protected $source;
+
     /**
      * @var RecordTransformerFactory
      */

--- a/src/Migration/Step/UrlRewrite/Model/Version11410to2000/ProductRewritesWithoutCategories.php
+++ b/src/Migration/Step/UrlRewrite/Model/Version11410to2000/ProductRewritesWithoutCategories.php
@@ -34,6 +34,8 @@ class ProductRewritesWithoutCategories implements ProductRewritesWithoutCategori
      */
     private $sourceAdapter;
 
+    private $suffix;
+
     /**
      * @param Source $source
      * @param Suffix $suffix

--- a/src/Migration/Step/UrlRewrite/Model/VersionCommerce/TemporaryTable.php
+++ b/src/Migration/Step/UrlRewrite/Model/VersionCommerce/TemporaryTable.php
@@ -125,6 +125,8 @@ class TemporaryTable
      */
     private $suffix;
 
+    private $configReader;
+
     /**
      * @var string[]
      */

--- a/src/Migration/Step/VisualMerchandiser/Volume.php
+++ b/src/Migration/Step/VisualMerchandiser/Volume.php
@@ -11,6 +11,8 @@ use Migration\Reader\GroupsFactory;
 use Migration\Reader\MapFactory;
 use Migration\ResourceModel;
 use Migration\App\ProgressBar;
+use Migration\Reader\Map;
+use Migration\Reader\Groups;
 
 /**
  * Class Volume
@@ -38,6 +40,16 @@ class Volume extends AbstractVolume
      * @var Logger
      */
     protected $logger;
+
+    /*
+     * Map
+     */
+    protected $map;
+
+    /*
+     * Groups
+     */
+    protected $groups;
 
     /**
      * @param Logger $logger


### PR DESCRIPTION
- Fix [ACP2E-2249: [DMT] Disable migration of directory_country_* tables](https://github.com/magento/data-migration-tool/commit/dd7f43014572a253e66e21acd2ade1b63eacbaaf)