### PR TITLE
Fix for 'Integrity constraint violation: 1062 Duplicate entry '11-general' for key'

### DIFF
--- a/src/Migration/Step/Eav/Model/Data.php
+++ b/src/Migration/Step/Eav/Model/Data.php
@@ -131,6 +131,25 @@ class Data
         return $attributeSets;
     }
 
+    public function getEntityAttributeSets(
+        $mode = self::ATTRIBUTE_SETS_ALL,
+        $type = self::TYPE_SOURCE,
+        $entityTypeCode = self::ENTITY_TYPE_PRODUCT_CODE
+    ) {
+        $productEntityTypeId = $this->getEntityTypeIdByCode($entityTypeCode, $type);
+        $attributeSets = [];
+        foreach ($this->initialData->getAttributeSets($type) as $attributeSet) {
+            if ($productEntityTypeId == $attributeSet['entity_type_id']
+                && (($mode == self::ATTRIBUTE_SETS_DEFAULT && $attributeSet['attribute_set_name'] == 'Default')
+                    || ($mode == self::ATTRIBUTE_SETS_NONE_DEFAULT && $attributeSet['attribute_set_name'] != 'Default')
+                    || ($mode == self::ATTRIBUTE_SETS_ALL))
+            ) {
+                $attributeSets[$attributeSet['attribute_set_id']] = $attributeSet;
+            }
+        }
+        return $attributeSets;
+    }
+
     /**
      * Return entity type id by its code
      *
@@ -196,6 +215,30 @@ class Data
             self::ATTRIBUTE_SETS_DEFAULT,
             self::TYPE_DEST
         );
+        $defaultProductAttributeSetId = array_shift($defaultProductAttributeSet)['attribute_set_id'];
+        $attributeGroups = [];
+        foreach ($this->initialData->getAttributeGroups(self::TYPE_DEST) as $attributeGroup) {
+            if ($attributeGroup['attribute_set_id'] == $defaultProductAttributeSetId) {
+                $attributeGroup['attribute_group_id'] = null;
+                $attributeGroup['attribute_set_id'] = null;
+                $attributeGroups[] = $attributeGroup;
+            }
+        }
+        return $attributeGroups;
+    }
+
+    public function getDefaultEntityAttributeGroups($entityTypeCode = self::ENTITY_TYPE_PRODUCT_CODE)
+    {
+        $defaultProductAttributeSet = $this->getEntityAttributeSets(
+            self::ATTRIBUTE_SETS_DEFAULT,
+            self::TYPE_DEST,
+            $entityTypeCode
+        );
+
+        if (!$defaultProductAttributeSet) {
+            return [];
+        }
+
         $defaultProductAttributeSetId = array_shift($defaultProductAttributeSet)['attribute_set_id'];
         $attributeGroups = [];
         foreach ($this->initialData->getAttributeGroups(self::TYPE_DEST) as $attributeGroup) {
@@ -298,17 +341,11 @@ class Data
         $sourceAttributeGroupNames = [];
         $entityTypeCode = $this->getEntityTypeCodeByAttributeSetId($attributeSetId);
         $excludedAttributeGroups = $this->excludedAttributeGroups[$entityTypeCode] ?? [];
-        if ($entityTypeCode == self::ENTITY_TYPE_PRODUCT_CODE) {
-            foreach ($this->getDefaultProductAttributeGroups() as $attributeGroup) {
-                $defaultAttributeGroupNames[] = $attributeGroup['attribute_group_name'];
-            }
-        } else {
-            foreach ($this->initialData->getAttributeGroups(self::TYPE_DEST) as $attributeGroup) {
-                if ($attributeGroup['attribute_set_id'] == $attributeSetId) {
-                    $defaultAttributeGroupNames[] = $attributeGroup['attribute_group_name'];
-                }
-            }
+
+        foreach ($this->getDefaultEntityAttributeGroups($entityTypeCode) as $attributeGroup) {
+            $defaultAttributeGroupNames[] = $attributeGroup['attribute_group_name'];
         }
+
         foreach ($this->initialData->getAttributeGroups(self::TYPE_SOURCE) as $attributeGroup) {
             if ($attributeGroup['attribute_set_id'] == $attributeSetId) {
                 if (in_array($attributeGroup['attribute_group_name'], $excludedAttributeGroups)) {


### PR DESCRIPTION
### Description
Resolves the way custom groups are migrated from Magento 1 to Magento 2.

Does away with the previous method of trying to find the default, non-product group logic which attempted to use the initialData to see what were the defaults. 

The problem was that it did not take into account the remapping of entity types and attribute sets and so was looking up Magento 1 groups on Magento 2 by attributeSetId which would have been changed.

This leads to it bugging and thinking some default groups need to be added as "custom groups" but this clashes with previous migration work that already remapped groups.

### Fixed Issues (if relevant)
1. https://github.com/magento/data-migration-tool/issues/869
2. https://github.com/magento/data-migration-tool/issues/928
3. https://github.com/magento/data-migration-tool/issues/920

### Manual testing scenarios
1. Try migrate Magento 1 data that contains the "General" attribute group associated with an attribute set for the entity types [11 , 16 , 23, 19]

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md file is updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
